### PR TITLE
Remove named person from GovGraph content

### DIFF
--- a/source/analysis/govgraph/index.html.md.erb
+++ b/source/analysis/govgraph/index.html.md.erb
@@ -35,5 +35,5 @@ For more information, see the following:
 
 If you have questions, you can contact the following groups on Slack:
 
-- [GOV.UK Data Labs team](https://gds.slack.com/archives/CHR4UQKU4)
-- [GOV.UK data champions](https://app.slack.com/client/T8GT9416G/C02CM46TD52)
+- the [GOV.UK Data Labs team](https://gds.slack.com/archives/CHR4UQKU4)
+- the [GOV.UK data champions](https://app.slack.com/client/T8GT9416G/C02CM46TD52)


### PR DESCRIPTION
Remove Esther Woods from GovGraph content, and replace her name with the GOV.UK Data Champions slack channel link.