### PR TITLE
Update publishing API connection commands

### DIFF
--- a/source/analysis/access-publishing/index.html.md.erb
+++ b/source/analysis/access-publishing/index.html.md.erb
@@ -27,7 +27,7 @@ See the [Get started on GOV.UK developer documentation](https://docs.publishing.
 1. Run the following in the command line to connect to an AWS instance in the integration environment:
 
     ```
-    USER=<FIRSTNAMELASTNAME>; gds govuk connect --environment integration ssh db_admin
+    USER=<FIRSTNAMELASTNAME>; gds govuk connect --environment integration ssh publishing_api_db_admin
     ```
 
     `<FIRSTNAMELASTNAME>` must be the same user that you created to SSH into integration.
@@ -37,7 +37,7 @@ See the [Get started on GOV.UK developer documentation](https://docs.publishing.
 1. Open a psql terminal to the `postgresql-primary` host as the `aws_db_admin` user, and connect to the publishing API database:
 
     ```
-    sudo psql -U aws_db_admin -h postgresql-primary --no-password -d publishing_api_production
+    sudo psql -U aws_db_admin -h publishing-api-postgres --no-password -d publishing_api_production
     ```
 
     This database is named `production`, but it is not in the production environment.


### PR DESCRIPTION
The db_admin host and database host have both changed.  See https://github.com/alphagov/govuk-puppet/pull/11419 and related work.