### PR TITLE
Change master branch name to main

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -36,3 +36,4 @@ prevent_indexing: false
 
 show_contribution_banner: true
 github_repo: alphagov/data-community-tech-docs
+github_branch: main


### PR DESCRIPTION
Make sure that `View source` link works by ensuring that master branch is correctly named main.