### PR TITLE
Add guidance for authenticating with GCP

### DIFF
--- a/source/analysis/google-cloud-platform/index.html.md.erb
+++ b/source/analysis/google-cloud-platform/index.html.md.erb
@@ -13,7 +13,7 @@ Google Cloud Platform (GCP) is a suite of cloud computing services. GDS maintain
 
 You already have access to GCP through your GDS Google Account.
 
-You will need specific roles and permissions to use each of the GCP services. If you need to run code unsupervised, that is without logging into your Google account, then you need a service account.
+You will need specific roles and permissions to use each of the GCP services. If you need to run code unsupervised, that is without logging into your Google account, then you need a service account. [It's unlikely that you will need a service account for personal use](https://cloud.google.com/iam/docs/best-practices-for-using-and-managing-service-accounts#development).
 
 [Contact the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU) to ask for a role, permission or service account.
 
@@ -23,19 +23,6 @@ You can use GCP through:
 - the command line on your local machine
 - code that runs on your local machine
 - code that runs on GCP
-
-## Google Groups
-
-TBC.
-
-___Recommend removing until finalised___
-
-## Service accounts
-
-Service accounts are created for code that needs to run unsupervised. It is unlikely that you will need a service account for personal use.
-
-___then why include the above content?___
-___why is this here?___
 
 ## Use GCP through the cloud console
 
@@ -53,18 +40,15 @@ Use the [Google Cloud CLI](https://cloud.google.com/sdk/gcloud) to:
 
 1. [Install the Google Cloud CLI](https://cloud.google.com/sdk/docs/install-sdk#mac) on your local machine.
 
-1. Run `gcloud init` to configure the Google Cloud CLI. Authorise gcloud to use your Google account when prompted in a separate window.
-___Run it in the normal CLI or the Google Cloud CLI?___
+1. Run `gcloud init` in the command line to configure the Google Cloud CLI. Authorise gcloud to use your Google account when prompted in a separate window.
 
 1. Once configuration is complete, you and your code are authenticated for an hour. You can refresh your authentication by running `gcloud auth login` in the command line.
-______Run it in the normal CLI or the Google Cloud CLI?___
 
 ## Use GCP through code that runs on your local machine
 
 1. Follow the [documentation on using GCP through the command line on your local machine]().
 
-1. Run `gcloud auth application-default login`.
-______Run it in the normal CLI or the Google Cloud CLI?___
+1. Run `gcloud auth login --update-adc` in the command line.
 
     Authorise gcloud to use your Google account when prompted in a separate window.
 
@@ -72,12 +56,13 @@ ______Run it in the normal CLI or the Google Cloud CLI?___
 
     Code that you run will use this file to authenticate itself on GCP.
 
-### Check that you can use GCP from code that runs on your local machine
+### Check that you can now use GCP through code that runs on your local machine
 
-___Should you do this before doing the above?___
+You should check that you can now use GCP through code that runs on your local machine.
 
-1. Obtain the role __BigQuery Job User__ for your account.
-___How?___
+If you cannot, this is likely to be an authentication issue.
+
+1. Get the __BigQuery Job User__ role for your GDS Google account by contacting the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU).
 
 1. Install the [BigQuery API client library for Python](https://cloud.google.com/bigquery/docs/reference/libraries#client-libraries-install-python) by running `pip install --upgrade google-cloud-bigquery` in the command line.
 
@@ -136,14 +121,15 @@ ___How?___
     name=Joe, count=87977
     ```
 
-___What should you do if you don't see this output?___
+If you do not see this output, then you currently cannot use GCP through code that runs on your local machine.
 
-### Access files on Google Drive such as Sheets and Docs
+[Contact the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU) to ask for help.
+
+### Access files on Google Drive
 
 1. Follow the [documentation on using GCP through code that runs on your local machine]().
 
 1. Run `gcloud auth login --enable-gdrive-access --update-adc` in the command line. The flag `--enable-gdrive-access` allows code to access files on Google Drive.
-___which command line?___
 
 1. Install the legacy Google API Python Client by running `pip install google-api-python-client` in the command line.
 
@@ -187,15 +173,14 @@ ___which command line?___
       print(err)
     ```
 
-1. Run the code at the command line with `python sheets.py -s=SHEET_ID -r=RANGE`, where:
+1. Run the code in this file by running `python sheets.py -s=SHEET_ID -r=RANGE` in the command line, where:
 
     - `SHEET_ID` is the ID of a sheet that that you can access
     - `RANGE` is the name of a tab and a range of cells, such as `Sheet1\!A1:E5`.
 
     You will probably need to escape the exclamation mark with a backslash, as shown in the example.
-___Run which code?___
 
-Expect the values of some cells in the sheet to be printed at the command line.
+    The values of some cells in this file sheet will be printed at the command line.
 
 ## Use GCP from code that runs on GCP
 
@@ -238,6 +223,6 @@ auth.authenticate_user()
 
 ## Avoid using a credentials file
 
-[You should not use a credentials file](https://cloud.google.com/blog/products/identity-security/how-to-authenticate-service-accounts-to-help-keep-applications-secure) because they pose a security risk. 
+[You should not use a credentials file](https://cloud.google.com/blog/products/identity-security/how-to-authenticate-service-accounts-to-help-keep-applications-secure) because they pose a security risk.
 
 The Google Cloud client libraries will automatically find the credentials that it needs, whether you are running code on your local device or in GCP itself.

--- a/source/analysis/google-cloud-platform/index.html.md.erb
+++ b/source/analysis/google-cloud-platform/index.html.md.erb
@@ -5,154 +5,209 @@ last_reviewed_on: 2022-04-01
 review_in: 6 months
 ---
 
-# Use Google Cloud Platform (GCP)
+# Use Google Cloud Platform
 
-GCP is a suite of cloud computing services.  GDS maintains a central account.
+Google Cloud Platform (GCP) is a suite of cloud computing services. GDS maintains a central account.
 
 ## Get access to GCP
 
-You already have access to GCP via your GDS Google Account (the same as you use for Gmail).
+You already have access to GCP through your GDS Google Account.
 
-You will need specific roles and permissions to use each of the services in GCP.  If you need some code to run unsupervised (without you personally logging into your Google account), then request a service account.
+You will need specific roles and permissions to use each of the GCP services. If you need to run code unsupervised, that is without logging into your Google account, then you need a service account.
 
-Roles, permissions and service accounts can be requested from the Data Engineering Community, via its slack channel #data-engineering.
+[Contact the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU) to ask for a role, permission or service account.
+
+You can use GCP through:
+
+- the cloud console
+- the command line on your local machine
+- code that runs on your local machine
+- code that runs on GCP
 
 ## Google Groups
 
 TBC.
 
+___Recommend removing until finalised___
+
 ## Service accounts
 
-Service accounts are created for code that needs to run unsupervised.  It is unlikely that you will need a service account for personal use.
+Service accounts are created for code that needs to run unsupervised. It is unlikely that you will need a service account for personal use.
 
-## Use GCP from the Cloud Console
+___then why include the above content?___
+___why is this here?___
 
-Go to https://console.cloud.google.com/ in a browser.  Alternatively, use Cloud Shell by going to https://console.cloud.google.com/home/dashboard?cloudshell=true in a browser.
+## Use GCP through the cloud console
 
-## Use GCP from the command line on your device
+You can use GCP from the cloud console by opening one of the following URLs in a web browser:
 
-Use the [Google Cloud CLI](https://cloud.google.com/sdk/gcloud) to interact with GCP, and to run code that interacts with GCP.
+- the [cloud console](https://console.cloud.google.com/)
+- the [cloud shell](https://console.cloud.google.com/home/dashboard?cloudshell=true)
 
-[Install the Google Cloud CLI](https://cloud.google.com/sdk/docs/install-sdk#mac).
+## Use GCP through the command line on your local machine
 
-Follow the instructions about setting it up by running `gcloud init`.  It will open a browser for you to authorise gcloud to use your Google account.
+Use the [Google Cloud CLI](https://cloud.google.com/sdk/gcloud) to:
 
-Once it has been set up, you and your code will be authenticated for an hour.  Refresh your authentication by running `gcloud auth login`.
+- interact directly with GCP
+- run code that interacts with GCP
 
-## Use GCP from code that runs on your device
+1. [Install the Google Cloud CLI](https://cloud.google.com/sdk/docs/install-sdk#mac) on your local machine.
 
-Follow the instructions "Use GCP from the command line".  Then run `gcloud auth application-default login`.  It will open a browser for you to authorise gcloud to use your Google account.  It will also create a file in a location that it prints at the command line, resembling `~/.config/gcloud/application_default_credentials.json`.  Code that you run will use this file to authenticate itself on GCP.
+1. Run `gcloud init` to configure the Google Cloud CLI. Authorise gcloud to use your Google account when prompted in a separate window.
+___Run it in the normal CLI or the Google Cloud CLI?___
 
-### Check that you can use GCP from code that runs on your device.
+1. Once configuration is complete, you and your code are authenticated for an hour. You can refresh your authentication by running `gcloud auth login` in the command line.
+______Run it in the normal CLI or the Google Cloud CLI?___
 
-Obtain the role BigQuery Job User for your account.
+## Use GCP through code that runs on your local machine
 
-Install the [BigQuery API client library for Python](https://cloud.google.com/bigquery/docs/reference/libraries#client-libraries-install-python) with `pip install --upgrade google-cloud-bigquery`.  It is best to do this in a new [python virtual environment](https://gds-way.cloudapps.digital/manuals/programming-languages/python/python.html#environments).
+1. Follow the [documentation on using GCP through the command line on your local machine]().
 
-Run `gcloud auth login --update-adc` at the command line.  The flag `--update-adc` allows code that you run to use your credentials.
+1. Run `gcloud auth application-default login`.
+______Run it in the normal CLI or the Google Cloud CLI?___
 
-Create a file called `bigquery.py` that contains the following code.
+    Authorise gcloud to use your Google account when prompted in a separate window.
 
-```python
-from google.cloud import bigquery
+    Running this command also creates a file in a location that it prints at the command line, `~/.config/gcloud/application_default_credentials.json`.
 
-# Construct a BigQuery client object.
-client = bigquery.Client(project="govuk-bigquery-analytics")
+    Code that you run will use this file to authenticate itself on GCP.
 
-query = """
-    SELECT name, SUM(number) as total_people
-    FROM `bigquery-public-data.usa_names.usa_1910_2013`
-    WHERE state = 'TX'
-    GROUP BY name, state
-    ORDER BY total_people DESC
-    LIMIT 20
-"""
+### Check that you can use GCP from code that runs on your local machine
 
-query_job = client.query(query)  # Make an API request.
+___Should you do this before doing the above?___
 
-print("The query data:")
-for row in query_job:
-    # Row values can be accessed by field name or index.
-    print("name={}, count={}".format(row[0], row["total_people"]))
-```
+1. Obtain the role __BigQuery Job User__ for your account.
+___How?___
 
-Run the code at the command line with `python bigquery.py`.  Expect to see the following result.
+1. Install the [BigQuery API client library for Python](https://cloud.google.com/bigquery/docs/reference/libraries#client-libraries-install-python) by running `pip install --upgrade google-cloud-bigquery` in the command line.
 
-```text
-The query data:
-name=James, count=272793
-name=John, count=235139
-name=Michael, count=225320
-name=Robert, count=220399
-name=David, count=219028
-name=Mary, count=209893
-name=William, count=173092
-name=Jose, count=157362
-name=Christopher, count=144196
-name=Maria, count=131056
-name=Charles, count=126509
-name=Daniel, count=117470
-name=Richard, count=109888
-name=Juan, count=109808
-name=Jennifer, count=98696
-name=Joshua, count=90679
-name=Elizabeth, count=90465
-name=Joseph, count=89097
-name=Matthew, count=88464
-name=Joe, count=87977
-```
+    You should do this in a new [python virtual environment](https://gds-way.cloudapps.digital/manuals/programming-languages/python/python.html#environments).
+
+1. Run `gcloud auth login --update-adc`. The flag `--update-adc` allows code that you run to use your credentials.
+
+1. Create a file called `bigquery.py` that contains the following code:
+
+    ```python
+    from google.cloud import bigquery
+
+    # Construct a BigQuery client object.
+    client = bigquery.Client(project="govuk-bigquery-analytics")
+
+    query = """
+      SELECT name, SUM(number) as total_people
+      FROM `bigquery-public-data.usa_names.usa_1910_2013`
+      WHERE state = 'TX'
+      GROUP BY name, state
+      ORDER BY total_people DESC
+      LIMIT 20
+    """
+
+    query_job = client.query(query) # Make an API request.
+
+    print("The query data:")
+    for row in query_job:
+      # Row values can be accessed by field name or index.
+      print("name={}, count={}".format(row[0], row["total_people"]))
+    ```
+
+1. Run the code at the command line with `python bigquery.py`. You should see the following output:
+
+    ```text
+    The query data:
+    name=James, count=272793
+    name=John, count=235139
+    name=Michael, count=225320
+    name=Robert, count=220399
+    name=David, count=219028
+    name=Mary, count=209893
+    name=William, count=173092
+    name=Jose, count=157362
+    name=Christopher, count=144196
+    name=Maria, count=131056
+    name=Charles, count=126509
+    name=Daniel, count=117470
+    name=Richard, count=109888
+    name=Juan, count=109808
+    name=Jennifer, count=98696
+    name=Joshua, count=90679
+    name=Elizabeth, count=90465
+    name=Joseph, count=89097
+    name=Matthew, count=88464
+    name=Joe, count=87977
+    ```
+
+___What should you do if you don't see this output?___
 
 ### Access files on Google Drive such as Sheets and Docs
 
-Follow the instructions "Use GCP from code that runs on your device" and "".
+1. Follow the [documentation on using GCP through code that runs on your local machine]().
 
-Run `gcloud auth login --enable-gdrive-access --update-adc` at the command line.  The flag `--enable-gdrive-access` allows code to access files on Google Drive, such as Sheets and Docs.
+1. Run `gcloud auth login --enable-gdrive-access --update-adc` in the command line. The flag `--enable-gdrive-access` allows code to access files on Google Drive.
+___which command line?___
 
-Install the legacy Google API Python Client by running `pip install google-api-python-client` at the command line.  It is best to do this in a new [python virtual environment](https://gds-way.cloudapps.digital/manuals/programming-languages/python/python.html#environments).  No newer client library supports Google Drive, Sheets or Docs.
+1. Install the legacy Google API Python Client by running `pip install google-api-python-client` in the command line.
 
-Create a file called `sheets.py` that contains the following code.
+    You should do this in a new [python virtual environment](https://gds-way.cloudapps.digital/manuals/programming-languages/python/python.html#environments).
 
-```python
-from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
-from pprint import pprint
-from argparse import ArgumentParser
+    No newer client library supports Google Drive, Sheets or Docs.
 
-parser = ArgumentParser()
-parser.add_argument("-s", "--sheet-id", dest="SHEET_ID",
-                    help="ID of a Google Sheet")
-parser.add_argument("-r", "--range", dest="RANGE",
-                    help="Range of cells in A1 or R1C1 notation")
-args = parser.parse_args()
+1. Create a file called `sheets.py` that contains the following code:
 
-# The ID and range of a sample spreadsheet.
-# SHEET_ID = '1ThBiDsAtMhfwvPXW39siZkZPdFS3FW_IGgQuET4YjnM'
-# RANGE = 'scores!A:E'
+    ```python
+    from googleapiclient.discovery import build
+    from googleapiclient.errors import HttpError
+    from pprint import pprint
+    from argparse import ArgumentParser
 
-try:
-    service = build('sheets', 'v4')
+    parser = ArgumentParser()
+    parser.add_argument("-s", "--sheet-id", dest="SHEET_ID",
+              help="ID of a Google Sheet")
+    parser.add_argument("-r", "--range", dest="RANGE",
+              help="Range of cells in A1 or R1C1 notation")
+    args = parser.parse_args()
 
-    # Call the Sheets API
-    result = service.spreadsheets().values().get(
+    # The ID and range of a sample spreadsheet.
+    # SHEET_ID = '1ThBiDsAtMhfwvPXW39siZkZPdFS3FW_IGgQuET4YjnM'
+    # RANGE = 'scores!A:E'
+
+    try:
+      service = build('sheets', 'v4')
+
+      # Call the Sheets API
+      result = service.spreadsheets().values().get(
         spreadsheetId=args.SHEET_ID, range=args.RANGE).execute()
-    rows = result.get('values', [])
+      rows = result.get('values', [])
 
-    if not rows:
+      if not rows:
         print('No data found.')
 
-    # print('{0} rows retrieved.'.format(len(rows)))
-    pprint(rows)
-except HttpError as err:
-    print(err)
-```
+      # print('{0} rows retrieved.'.format(len(rows)))
+      pprint(rows)
+    except HttpError as err:
+      print(err)
+    ```
 
-Run the code at the command line with `python sheets.py -s=SHEET_ID -r=RANGE`, where `SHEET_ID` is the ID of a sheet that that you can access, and `RANGE` is the name of a tab and a range of cells, such as `Sheet1\!A1:E5`.  You will probably need to escape the exclamation mark with a backslash, as shown in the example.
+1. Run the code at the command line with `python sheets.py -s=SHEET_ID -r=RANGE`, where:
+
+    - `SHEET_ID` is the ID of a sheet that that you can access
+    - `RANGE` is the name of a tab and a range of cells, such as `Sheet1\!A1:E5`.
+
+    You will probably need to escape the exclamation mark with a backslash, as shown in the example.
+___Run which code?___
 
 Expect the values of some cells in the sheet to be printed at the command line.
 
-## Use GCP from code that runs on GCP itself
+## Use GCP from code that runs on GCP
 
-Request a [service account](https://cloud.google.com/iam/docs/service-accounts) from the slack channel #data-engineering, saying what roles and permissions it requires.  Ask for the service account to be attached to the resource in GCP that the code will run in.  There should be no need to modify your code, because it will automatically find and use the service account credentials.
+[Contact the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU) to ask for a service account, saying what roles and permissions it requires.
+___Conflicts slightly with the section at the start about probably not needing a service account?___
+___How do I know what roles and permissions it needs?___
+
+Ask for the service account to be attached to the resource in GCP that the code will run in.
+___How?___
+
+There should be no need to modify your code, because it will automatically find and use the service account credentials.
+___Is "it" the code?___
 
 ### Access files on Google Drive, such as Sheets and Docs, using a service account
 
@@ -160,15 +215,19 @@ In Google Drive, share the files with the email address of the service account.
 
 ## Impersonate a service account on your local device
 
-Obtain a service account that grants your personal account the role "Service Account Token Creator", which includes the permission "iam.serviceAccounts.getAccessToken".  Note the email address of the service account.
+1. Obtain a service account that grants your personal account the role "Service Account Token Creator", which includes the permission "iam.serviceAccounts.getAccessToken". Note the email address of the service account.
+___Through data engineering slack?___
 
-Follow the instructions "Use GCP from the command line".  Then run `gcloud auth application-default login --impersonate-service-account=EMAIL_ADDRESS`, where `EMAIL_ADDRESS` is the one of the service account, ending in `.iam.gserviceaccount.com`.
+1. Follow the [documentation on using GCP through the command line on your local machine]().
+
+1. Run `gcloud auth application-default login --impersonate-service-account=EMAIL_ADDRESS`, where `EMAIL_ADDRESS` is the email of the service account, ending in `.iam.gserviceaccount.com`.
+___In a specific command line? the Google cloud one?___
 
 The Google Cloud client libraries will now use the service account.
 
 ## Use GCP from code that runs on Google Colab
 
-Paste the following code into a cell in a Colab notebook.
+Paste and run the following code into a cell in a Colab notebook.
 
 ```py
 from google.colab import auth
@@ -179,4 +238,6 @@ auth.authenticate_user()
 
 ## Avoid using a credentials file
 
-It is [best practice](https://cloud.google.com/blog/products/identity-security/how-to-authenticate-service-accounts-to-help-keep-applications-secure) not to use a credentials file, because they pose a security risk.  The Google Cloud client libraries will automatically find the credentials that it needs, whether you are running code on your local device or in GCP itself.
+[You should not use a credentials file](https://cloud.google.com/blog/products/identity-security/how-to-authenticate-service-accounts-to-help-keep-applications-secure) because they pose a security risk. 
+
+The Google Cloud client libraries will automatically find the credentials that it needs, whether you are running code on your local device or in GCP itself.

--- a/source/analysis/google-cloud-platform/index.html.md.erb
+++ b/source/analysis/google-cloud-platform/index.html.md.erb
@@ -47,9 +47,11 @@ Follow the instructions "Use GCP from the command line".  Then run `gcloud auth 
 
 Obtain the role BigQuery Job User for your account.
 
-Run `gcloud auth login` at the command line.
+Install the [BigQuery API client library for Python](https://cloud.google.com/bigquery/docs/reference/libraries#client-libraries-install-python) with `pip install --upgrade google-cloud-bigquery`.  It is best to do this in a new [python virtual environment](https://gds-way.cloudapps.digital/manuals/programming-languages/python/python.html#environments).
 
-Run the following python script.
+Run `gcloud auth login --update-adc` at the command line.  The flag `--update-adc` allows code that you run to use your credentials.
+
+Create a file called `bigquery.py` that contains the following code.
 
 ```python
 from google.cloud import bigquery
@@ -74,7 +76,7 @@ for row in query_job:
     print("name={}, count={}".format(row[0], row["total_people"]))
 ```
 
-Expect to see the following result.
+Run the code at the command line with `python bigquery.py`.  Expect to see the following result.
 
 ```text
 The query data:

--- a/source/analysis/google-cloud-platform/index.html.md.erb
+++ b/source/analysis/google-cloud-platform/index.html.md.erb
@@ -152,7 +152,11 @@ Expect the values of some cells in the sheet to be printed at the command line.
 
 ## Use GCP from code that runs on GCP itself
 
-Request a [service account](https://cloud.google.com/iam/docs/service-accounts) from the slack channel #data-engineering, saying what roles and permissions it requires.  Ask for the service account to be attached to the resource in GCP that the code will run in.
+Request a [service account](https://cloud.google.com/iam/docs/service-accounts) from the slack channel #data-engineering, saying what roles and permissions it requires.  Ask for the service account to be attached to the resource in GCP that the code will run in.  There should be no need to modify your code, because it will automatically find and use the service account credentials.
+
+### Access files on Google Drive, such as Sheets and Docs, using a service account
+
+In Google Drive, share the files with the email address of the service account.
 
 ## Impersonate a service account on your local device
 

--- a/source/analysis/google-cloud-platform/index.html.md.erb
+++ b/source/analysis/google-cloud-platform/index.html.md.erb
@@ -102,6 +102,54 @@ name=Matthew, count=88464
 name=Joe, count=87977
 ```
 
+### Access files on Google Drive such as Sheets and Docs
+
+Follow the instructions "Use GCP from code that runs on your device" and "".
+
+Run `gcloud auth login --enable-gdrive-access --update-adc` at the command line.  The flag `--enable-gdrive-access` allows code to access files on Google Drive, such as Sheets and Docs.
+
+Install the legacy Google API Python Client by running `pip install google-api-python-client` at the command line.  It is best to do this in a new [python virtual environment](https://gds-way.cloudapps.digital/manuals/programming-languages/python/python.html#environments).  No newer client library supports Google Drive, Sheets or Docs.
+
+Create a file called `sheets.py` that contains the following code.
+
+```python
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from pprint import pprint
+from argparse import ArgumentParser
+
+parser = ArgumentParser()
+parser.add_argument("-s", "--sheet-id", dest="SHEET_ID",
+                    help="ID of a Google Sheet")
+parser.add_argument("-r", "--range", dest="RANGE",
+                    help="Range of cells in A1 or R1C1 notation")
+args = parser.parse_args()
+
+# The ID and range of a sample spreadsheet.
+# SHEET_ID = '1ThBiDsAtMhfwvPXW39siZkZPdFS3FW_IGgQuET4YjnM'
+# RANGE = 'scores!A:E'
+
+try:
+    service = build('sheets', 'v4')
+
+    # Call the Sheets API
+    result = service.spreadsheets().values().get(
+        spreadsheetId=args.SHEET_ID, range=args.RANGE).execute()
+    rows = result.get('values', [])
+
+    if not rows:
+        print('No data found.')
+
+    # print('{0} rows retrieved.'.format(len(rows)))
+    pprint(rows)
+except HttpError as err:
+    print(err)
+```
+
+Run the code at the command line with `python sheets.py -s=SHEET_ID -r=RANGE`, where `SHEET_ID` is the ID of a sheet that that you can access, and `RANGE` is the name of a tab and a range of cells, such as `Sheet1\!A1:E5`.  You will probably need to escape the exclamation mark with a backslash, as shown in the example.
+
+Expect the values of some cells in the sheet to be printed at the command line.
+
 ## Use GCP from code that runs on GCP itself
 
 Request a [service account](https://cloud.google.com/iam/docs/service-accounts) from the slack channel #data-engineering, saying what roles and permissions it requires.  Ask for the service account to be attached to the resource in GCP that the code will run in.

--- a/source/analysis/google-cloud-platform/index.html.md.erb
+++ b/source/analysis/google-cloud-platform/index.html.md.erb
@@ -13,16 +13,26 @@ Google Cloud Platform (GCP) is a suite of cloud computing services. GDS maintain
 
 You already have access to GCP through your GDS Google Account.
 
-You will need specific roles and permissions to use each of the GCP services. If you need to run code unsupervised, that is without logging into your Google account, then you need a service account. [It's unlikely that you will need a service account for personal use](https://cloud.google.com/iam/docs/best-practices-for-using-and-managing-service-accounts#development).
-
-[Contact the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU) to ask for a role, permission or service account.
-
 You can use GCP through:
 
 - the cloud console
 - the command line on your local machine
 - code that runs on your local machine
 - code that runs on GCP
+
+You will need specific roles and permissions to use each of the GCP services.
+
+### Get a specific role or permissions to use GCP
+
+A role is a set of permissions. You should only have the specific role or permissions you need to use the GCP.
+
+See the [Google Cloud documentation on understanding roles](https://cloud.google.com/iam/docs/understanding-roles) and the [IAM permissions reference](https://cloud.google.com/iam/docs/permissions-reference) for more information.
+
+If your code fails to run, check the error message to see if there was a role or permission error.
+
+If you need to run code unsupervised, that is without logging into your Google account, then you need a service account. [It's unlikely that you will need a service account for personal use](https://cloud.google.com/iam/docs/best-practices-for-using-and-managing-service-accounts#development).
+
+[Contact the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU) to ask for a role, permission or service account.
 
 ## Use GCP through the cloud console
 
@@ -33,28 +43,28 @@ You can use GCP from the cloud console by opening one of the following URLs in a
 
 ## Use GCP through the command line on your local machine
 
-Use the [Google Cloud CLI](https://cloud.google.com/sdk/gcloud) to:
+You can use the [Google Cloud CLI](https://cloud.google.com/sdk/gcloud) to:
 
 - interact directly with GCP
 - run code that interacts with GCP
 
 1. [Install the Google Cloud CLI](https://cloud.google.com/sdk/docs/install-sdk#mac) on your local machine.
 
-1. Run `gcloud init` in the command line to configure the Google Cloud CLI. Authorise gcloud to use your Google account when prompted in a separate window.
+1. Run `gcloud init` in the command line to configure the Google Cloud CLI. Authorise the Google Cloud CLI to use your Google account when prompted in a separate window.
 
 1. Once configuration is complete, you and your code are authenticated for an hour. You can refresh your authentication by running `gcloud auth login` in the command line.
 
 ## Use GCP through code that runs on your local machine
 
-1. Follow the [documentation on using GCP through the command line on your local machine]().
+1. Follow the [documentation on using GCP through the command line on your local machine](#use-gcp-through-the-command-line-on-your-local-machine).
 
 1. Run `gcloud auth login --update-adc` in the command line.
 
     Authorise gcloud to use your Google account when prompted in a separate window.
 
-    Running this command also creates a file in a location that it prints at the command line, `~/.config/gcloud/application_default_credentials.json`.
+Running this command also creates a file in a location that it prints at the command line, `~/.config/gcloud/application_default_credentials.json`.
 
-    Code that you run will use this file to authenticate itself on GCP.
+Code that you run will use this file to authenticate itself on GCP.
 
 ### Check that you can now use GCP through code that runs on your local machine
 
@@ -62,7 +72,7 @@ You should check that you can now use GCP through code that runs on your local m
 
 If you cannot, this is likely to be an authentication issue.
 
-1. Get the __BigQuery Job User__ role for your GDS Google account by contacting the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU).
+1. Get the __BigQuery Job User__ role for your GDS Google account by [contacting the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU).
 
 1. Install the [BigQuery API client library for Python](https://cloud.google.com/bigquery/docs/reference/libraries#client-libraries-install-python) by running `pip install --upgrade google-cloud-bigquery` in the command line.
 
@@ -95,7 +105,7 @@ If you cannot, this is likely to be an authentication issue.
       print("name={}, count={}".format(row[0], row["total_people"]))
     ```
 
-1. Run the code at the command line with `python bigquery.py`. You should see the following output:
+1. Run `python bigquery.py` in the command line. You should see the following output:
 
     ```text
     The query data:
@@ -127,7 +137,7 @@ If you do not see this output, then you currently cannot use GCP through code th
 
 ### Access files on Google Drive
 
-1. Follow the [documentation on using GCP through code that runs on your local machine]().
+1. Follow the [documentation on using GCP through code that runs on your local machine](http://localhost:4567/analysis/google-cloud-platform/#use-gcp-through-the-command-line-on-your-local-machine).
 
 1. Run `gcloud auth login --enable-gdrive-access --update-adc` in the command line. The flag `--enable-gdrive-access` allows code to access files on Google Drive.
 
@@ -182,17 +192,17 @@ If you do not see this output, then you currently cannot use GCP through code th
 
     The values of some cells in this file sheet will be printed at the command line.
 
-## Use GCP from code that runs on GCP
+## Use GCP through code that runs on GCP
 
-[Contact the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU) to ask for a service account, saying what roles and permissions it requires.
-___Conflicts slightly with the section at the start about probably not needing a service account?___
-___How do I know what roles and permissions it needs?___
+You can use the GCP through code that runs on the GCP itself.
 
-Ask for the service account to be attached to the resource in GCP that the code will run in.
-___How?___
+This is the same as running code unsupervised or automatically as part of a service, without needing to log into your Google account.
 
-There should be no need to modify your code, because it will automatically find and use the service account credentials.
-___Is "it" the code?___
+Therefore you need a service account. [Contact the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU) to ask for a service account, saying what [roles and permissions]() it requires.
+
+[Contact the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU) to ask for the service account to be attached to the resource in GCP that the code will run in.
+
+You should not need to modify your code, because this code will automatically find and use the service account credentials.
 
 ### Access files on Google Drive, such as Sheets and Docs, using a service account
 
@@ -200,13 +210,13 @@ In Google Drive, share the files with the email address of the service account.
 
 ## Impersonate a service account on your local device
 
-1. Obtain a service account that grants your personal account the role "Service Account Token Creator", which includes the permission "iam.serviceAccounts.getAccessToken". Note the email address of the service account.
-___Through data engineering slack?___
+1. [Contact the Data Engineering community on Slack](https://gds.slack.com/archives/C032AH1D6MU) to get a service account that grants your personal account the role __Service Account Token Creator__, which includes the permission __iam.serviceAccounts.getAccessToken__.
 
-1. Follow the [documentation on using GCP through the command line on your local machine]().
+    Note the email address of the service account.
 
-1. Run `gcloud auth application-default login --impersonate-service-account=EMAIL_ADDRESS`, where `EMAIL_ADDRESS` is the email of the service account, ending in `.iam.gserviceaccount.com`.
-___In a specific command line? the Google cloud one?___
+1. Follow the [documentation on using GCP through the command line on your local machine](http://localhost:4567/analysis/google-cloud-platform/#use-gcp-through-the-command-line-on-your-local-machine).
+
+1. Run `gcloud auth application-default login --impersonate-service-account=EMAIL_ADDRESS` on the command line, where `EMAIL_ADDRESS` is the email of the service account, ending in `.iam.gserviceaccount.com`.
 
 The Google Cloud client libraries will now use the service account.
 

--- a/source/analysis/google-cloud-platform/index.html.md.erb
+++ b/source/analysis/google-cloud-platform/index.html.md.erb
@@ -166,6 +166,17 @@ Follow the instructions "Use GCP from the command line".  Then run `gcloud auth 
 
 The Google Cloud client libraries will now use the service account.
 
+## Use GCP from code that runs on Google Colab
+
+Paste the following code into a cell in a Colab notebook.
+
+```py
+from google.colab import auth
+
+# Authenticate the user - follow the link and the prompts to get an authentication token
+auth.authenticate_user()
+```
+
 ## Avoid using a credentials file
 
 It is [best practice](https://cloud.google.com/blog/products/identity-security/how-to-authenticate-service-accounts-to-help-keep-applications-secure) not to use a credentials file, because they pose a security risk.  The Google Cloud client libraries will automatically find the credentials that it needs, whether you are running code on your local device or in GCP itself.

--- a/source/analysis/google-cloud-platform/index.html.md.erb
+++ b/source/analysis/google-cloud-platform/index.html.md.erb
@@ -137,7 +137,7 @@ If you do not see this output, then you currently cannot use GCP through code th
 
 ### Access files on Google Drive
 
-1. Follow the [documentation on using GCP through code that runs on your local machine](http://localhost:4567/analysis/google-cloud-platform/#use-gcp-through-the-command-line-on-your-local-machine).
+1. Follow the [documentation on using GCP through code that runs on your local machine](#use-gcp-through-the-command-line-on-your-local-machine).
 
 1. Run `gcloud auth login --enable-gdrive-access --update-adc` in the command line. The flag `--enable-gdrive-access` allows code to access files on Google Drive.
 
@@ -214,7 +214,7 @@ In Google Drive, share the files with the email address of the service account.
 
     Note the email address of the service account.
 
-1. Follow the [documentation on using GCP through the command line on your local machine](http://localhost:4567/analysis/google-cloud-platform/#use-gcp-through-the-command-line-on-your-local-machine).
+1. Follow the [documentation on using GCP through the command line on your local machine](#use-gcp-through-the-command-line-on-your-local-machine).
 
 1. Run `gcloud auth application-default login --impersonate-service-account=EMAIL_ADDRESS` on the command line, where `EMAIL_ADDRESS` is the email of the service account, ending in `.iam.gserviceaccount.com`.
 

--- a/source/analysis/google-cloud-platform/index.html.md.erb
+++ b/source/analysis/google-cloud-platform/index.html.md.erb
@@ -1,0 +1,117 @@
+---
+title: Use Google Cloud Platform
+weight: 31
+last_reviewed_on: 2022-04-01
+review_in: 6 months
+---
+
+# Use Google Cloud Platform (GCP)
+
+GCP is a suite of cloud computing services.  GDS maintains a central account.
+
+## Get access to GCP
+
+You already have access to GCP via your GDS Google Account (the same as you use for Gmail).
+
+You will need specific roles and permissions to use each of the services in GCP.  If you need some code to run unsupervised (without you personally logging into your Google account), then request a service account.
+
+Roles, permissions and service accounts can be requested from the Data Engineering Community, via its slack channel #data-engineering.
+
+## Google Groups
+
+TBC.
+
+## Service accounts
+
+Service accounts are created for code that needs to run unsupervised.  It is unlikely that you will need a service account for personal use.
+
+## Use GCP from the Cloud Console
+
+Go to https://console.cloud.google.com/ in a browser.  Alternatively, use Cloud Shell by going to https://console.cloud.google.com/home/dashboard?cloudshell=true in a browser.
+
+## Use GCP from the command line on your device
+
+Use the [Google Cloud CLI](https://cloud.google.com/sdk/gcloud) to interact with GCP, and to run code that interacts with GCP.
+
+[Install the Google Cloud CLI](https://cloud.google.com/sdk/docs/install-sdk#mac).
+
+Follow the instructions about setting it up by running `gcloud init`.  It will open a browser for you to authorise gcloud to use your Google account.
+
+Once it has been set up, you and your code will be authenticated for an hour.  Refresh your authentication by running `gcloud auth login`.
+
+## Use GCP from code that runs on your device
+
+Follow the instructions "Use GCP from the command line".  Then run `gcloud auth application-default login`.  It will open a browser for you to authorise gcloud to use your Google account.  It will also create a file in a location that it prints at the command line, resembling `~/.config/gcloud/application_default_credentials.json`.  Code that you run will use this file to authenticate itself on GCP.
+
+### Check that you can use GCP from code that runs on your device.
+
+Obtain the role BigQuery Job User for your account.
+
+Run `gcloud auth login` at the command line.
+
+Run the following python script.
+
+```python
+from google.cloud import bigquery
+
+# Construct a BigQuery client object.
+client = bigquery.Client(project="govuk-bigquery-analytics")
+
+query = """
+    SELECT name, SUM(number) as total_people
+    FROM `bigquery-public-data.usa_names.usa_1910_2013`
+    WHERE state = 'TX'
+    GROUP BY name, state
+    ORDER BY total_people DESC
+    LIMIT 20
+"""
+
+query_job = client.query(query)  # Make an API request.
+
+print("The query data:")
+for row in query_job:
+    # Row values can be accessed by field name or index.
+    print("name={}, count={}".format(row[0], row["total_people"]))
+```
+
+Expect to see the following result.
+
+```text
+The query data:
+name=James, count=272793
+name=John, count=235139
+name=Michael, count=225320
+name=Robert, count=220399
+name=David, count=219028
+name=Mary, count=209893
+name=William, count=173092
+name=Jose, count=157362
+name=Christopher, count=144196
+name=Maria, count=131056
+name=Charles, count=126509
+name=Daniel, count=117470
+name=Richard, count=109888
+name=Juan, count=109808
+name=Jennifer, count=98696
+name=Joshua, count=90679
+name=Elizabeth, count=90465
+name=Joseph, count=89097
+name=Matthew, count=88464
+name=Joe, count=87977
+```
+
+## Use GCP from code that runs on GCP itself
+
+Request a [service account](https://cloud.google.com/iam/docs/service-accounts) from the slack channel #data-engineering, saying what roles and permissions it requires.  Ask for the service account to be attached to the resource in GCP that the code will run in.
+
+## Impersonate a service account on your local device
+
+Obtain a service account that grants your personal account the role "Service Account Token Creator", which includes the permission "iam.serviceAccounts.getAccessToken".  Note the email address of the service account.
+
+Follow the instructions "Use GCP from the command line".  Then run `gcloud auth application-default login --impersonate-service-account=EMAIL_ADDRESS`, where `EMAIL_ADDRESS` is the one of the service account, ending in `.iam.gserviceaccount.com`.
+
+The Google Cloud client libraries will now use the service account.
+
+## Avoid using a credentials file
+
+It is [best practice](https://cloud.google.com/blog/products/identity-security/how-to-authenticate-service-accounts-to-help-keep-applications-secure) not to use a credentials file, because they pose a security risk.  The Google Cloud client libraries will automatically find the credentials that it needs, whether you are running code on your local device or in GCP itself.

--- a/source/analysis/google-cloud-platform/index.html.md.erb
+++ b/source/analysis/google-cloud-platform/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use Google Cloud Platform
-weight: 31
+weight: 40
 last_reviewed_on: 2022-04-01
 review_in: 6 months
 ---


### PR DESCRIPTION
We are changing the way that we authenticate ourselves and our code on the Google Cloud Platform.  This is the first draft of guidance for the new way of working.

We need this first bit of guidance to wean ourselves off personal service accounts.

A second piece of guidance (or an update of this) will explain how to use Google Groups to obtain roles and permissions, rather than attaching them to individual accounts.