### PR TITLE
Explain about using threads

### DIFF
--- a/source/analysis/access-publishing/index.html.md.erb
+++ b/source/analysis/access-publishing/index.html.md.erb
@@ -94,6 +94,7 @@ The following content assumes you’re using [PostgreSQL](https://www.postgresql
     ```sh
     pg_restore --verbose --create --jobs=4 --dbname=postgres publishing-api.pgdump
     ```
+    where `--jobs=4` is the number of CPU threads that will be used.  You can change this to suit your device.
 
 When your command line becomes responsive and you can enter commands again, this means you’ll have successfully created a database named `publishing_api_production` that contains the publishing API backup data.
 


### PR DESCRIPTION
Explain a parameter that is suggested `--jobs=4`, and that users may change the number to suit the machine that they use.  For example, a more powerful laptop would have more threads available.