### PR TITLE
Reviewing and updating 'User journey tools' documentation

### DIFF
--- a/source/analysis/forward-path/index.html.md.erb
+++ b/source/analysis/forward-path/index.html.md.erb
@@ -132,7 +132,7 @@ You will see a box asking if you are happy to create the Google Sheet.
 
 If you are happy to create the Google Sheet, enter "yes" into the user input box. If you leave the input box blank or enter something other than "yes", the query will not run.
 
-The query will create the Google Sheet and provide a link to this spreadsheet under the __Create google sheet in Product and Technology Directorate > Data Services > Data Products > 16 User Journey tools > Path tools: google sheet result tables__ cell.
+The query will create the Google Sheet and provide a link to this spreadsheet under the __Create google sheet in Product and Technology Directorate/Data Services/Data Products/16 User Journey tools/Path tools: google sheet result tables__ cell.
 
 This Google Sheet follows the [forward page path template](https://docs.google.com/spreadsheets/d/1kISyKu2jVzINCxwPe8ydQM8cibgEX2a3WCPxkJM9W80/edit#gid=1115034830).
 

--- a/source/analysis/forward-path/index.html.md.erb
+++ b/source/analysis/forward-path/index.html.md.erb
@@ -132,7 +132,7 @@ You will see a box asking if you are happy to create the Google Sheet.
 
 If you are happy to create the Google Sheet, enter "yes" into the user input box. If you leave the input box blank or enter something other than "yes", the query will not run.
 
-The query will create the Google Sheet and provide a link to this spreadsheet under the __Create google sheet in GOV.UK teams/2021-2022/Data labs/16 User journey tools/Path tools: google sheet result tables__ cell.
+The query will create the Google Sheet and provide a link to this spreadsheet under the __Create google sheet in Product and Technology Directorate > Data Services > Data Products > 16 User Journey tools > Path tools: google sheet result tables__ cell.
 
 This Google Sheet follows the [forward page path template](https://docs.google.com/spreadsheets/d/1kISyKu2jVzINCxwPe8ydQM8cibgEX2a3WCPxkJM9W80/edit#gid=1115034830).
 

--- a/source/analysis/pogostick/index.html.md.erb
+++ b/source/analysis/pogostick/index.html.md.erb
@@ -19,5 +19,5 @@ There are 2 types of pogo-sticking:
 There are 3 pogo-sticking dashboards:
 
 - the [main pogo-sticking dashboard](/analysis/pogostick/main/) is for all users and shows the internal and external pogo-sticking rate for GOV.UK pages
-- the [pogo-sticking dashboard page tracking dashboard](/analysis/pogostick/tracking/) is for the GOV.UK Data Products team and shows if the main pogo-sticking dashboard is being used, and how
+- the [pogo-sticking dashboard page tracking dashboard](/analysis/pogostick/tracking/) is for the Data Products team and shows if the main pogo-sticking dashboard is being used, and how
 - the [pogo-sticking between ‘smart answer clicked’ pages dashboard](/analysis/pogostick/smartanswer/) shows the pogo sticking rate when a user clicks a link that opens in a new tab, and this link triggers a `SmartAnswerClicked` event

--- a/source/analysis/reverse-path/index.html.md.erb
+++ b/source/analysis/reverse-path/index.html.md.erb
@@ -132,7 +132,7 @@ You will see a box asking if you are happy to create the Google Sheet.
 
 If you are happy to create the Google Sheet, enter "yes" into the user input box. If you leave the input box blank or enter something other than "yes", the query will not run.
 
-The query will create the Google Sheet and provide a link to this spreadsheet under the __Create google sheet in Product and Technology Directorate > Data Services > Data Products > 16 User Journey tools > Path tools: google sheet result tables__ cell.
+The query will create the Google Sheet and provide a link to this spreadsheet under the __Create google sheet in Product and Technology Directorate/Data Services/Data Products/16 User Journey tools/Path tools: google sheet result tables__ cell.
 
 This Google Sheet follows the [reverse page path template](https://docs.google.com/spreadsheets/d/1E54VgFepSCxNfNKNtxp8eQXme7wGOAEauTqgzEuz3iM/edit?usp=drive_web&ouid=114104082491527752510).
 

--- a/source/analysis/reverse-path/index.html.md.erb
+++ b/source/analysis/reverse-path/index.html.md.erb
@@ -132,7 +132,7 @@ You will see a box asking if you are happy to create the Google Sheet.
 
 If you are happy to create the Google Sheet, enter "yes" into the user input box. If you leave the input box blank or enter something other than "yes", the query will not run.
 
-The query will create the Google Sheet and provide a link to this spreadsheet under the __Create google sheet in GOV.UK teams/2021-2022/Data labs/16 User journey tools/Path tools: google sheet result tables__ cell.
+The query will create the Google Sheet and provide a link to this spreadsheet under the __Create google sheet in Product and Technology Directorate > Data Services > Data Products > 16 User Journey tools > Path tools: google sheet result tables__ cell.
 
 This Google Sheet follows the [reverse page path template](https://docs.google.com/spreadsheets/d/1E54VgFepSCxNfNKNtxp8eQXme7wGOAEauTqgzEuz3iM/edit?usp=drive_web&ouid=114104082491527752510).
 


### PR DESCRIPTION
I've reviewed the documentation for: 

- pogo-sticking
- forward path tool
- reverse path tool
- spider diagram tool 

Only three updates were needed to be made:
- the folder location where the google sheets tables are saved for the forward path tool
- the folder location where the google sheets tables are saved for the reverse path tool
- removing `GOV.UK` from the `Data Products` team, as the team does not sit within `GOV.UK` 