### PR TITLE
Fix CSS by setting prefix for all URLs

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -3,3 +3,4 @@ require 'govuk_tech_docs'
 GovukTechDocs.configure(self)
 
 config[:port] = 8080
+config[:http_prefix] = '/data-community-tech-docs'


### PR DESCRIPTION
Following a suggestion in a blog post:
https://manas.tech/blog/2020/07/07/deploying-middleman-with-github-actions/

The CSS (and other files) weren't being found, because they were being
sought at https://alphagov.github.io/ instead of
https://alphagov.github.io/data-community-tech-docs/
