### PR TITLE
Adding some of Tim's documentation on the contents of the GA4 data

### DIFF
--- a/source/analysis/govuk-ga4/ga4-data-information/index.html.md.erb
+++ b/source/analysis/govuk-ga4/ga4-data-information/index.html.md.erb
@@ -1,0 +1,51 @@
+---
+title: What can I learn from the GOV.UK GA4 data?
+weight: 1
+last_reviewed_on: 2024-03-25
+review_in: 6 months
+---
+
+# What can I learn from the GOV.UK GA4 data?
+<span style="color:red">This page is a work in progress.</span>
+
+The [GOV.UK Google Analytics 4 data](/data-sources/ga/ga4/) contains a variety of information on users of GOV.UK, and how those users interacted with various pages on GOV.UK.
+
+## Information about how users interacted with pages on GOV.UK
+
+GA4 data is the primary source of information on how users interacted with pages on GOV.UK.
+
+Things you can learn from the GA4 data include:
+
+- page views: how many times the page in question was viewed
+- sessions: how many sessions included a view of the page. Some pages may be viewed multiple times in the same session, so a count of sessions can sometimes be useful to de-dupe the count of page views. You can also report on the number of times a page was viewed per session
+- users: the number of active users who viewed the page. Although this sounds like an attractive metric to report, this figure does not correspond to the actual number of people viewing a page and is likely to give an inflated idea of the level of use
+- entrances: how often a session started on the page
+- navigation events: whether users clicked on links from the page in question
+- search events: whether users searched from the page in question
+- feedback events: whether users answered the feedback form on the page 
+
+## Information about users of pages on GOV.UK
+
+GA4 data also contains some information on the users of GOV.UK.
+
+Things you can learn from the GA4 data include:
+- device category: whether users were viewing GOV.UK pages from their phone, desktop, tablet, etc
+- session source/medium: how users got to GOV.UK
+- page referrer: what page or external source led the user to this page
+- language: the user's browser language setting
+- location: an indication of where most users seem to be (country, region, etc)
+
+## Information about the pages on GOV.UK
+
+GA4 data also contains some information on GOV.UK pages themselves.
+
+For instance, the GOV.UK GA4 data contains information on: 
+
+- the page's URL. Often, the best dimension to use here is page path and screen class (the URL of the page, excluding the protocol, hostname, and any additional parameters that might be appended to the end of the URL). Other variants of the URL exist in the data but can be more complicated to use in reports
+- page title
+- the page status code. A status code of 200 indicates success, whereas other codes (most commonly, '404' - 'Page not found’) indicate that the page was not served correctly
+- browse topic, taxonomy level 1, taxonomy main topic, taxonomy topics: information on how the page is categorised on GOV.UK
+- publishing organisation IDs: which departments have been tagged as relevant to this page
+- primary publishing organisation: the department which has been tagged as the primary publishing organisation
+- document type, schema name, publishing application, rendering application: technical information on the type of page this is and how it is published to GOV.UK
+

--- a/source/analysis/govuk-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Understand and use the GOV.UK GA4 data
 weight: 31
-last_reviewed_on: 2024-02-27
+last_reviewed_on: 2024-03-25
 review_in: 6 months
 ---
 
@@ -11,7 +11,8 @@ Google Analytics 4 (GA4) is used to collect data on the usage of GOV.UK.
 
 More information about the different GOV.UK GA4 data sources can be found on the [GOV.UK GA4 data source pages](/data-sources/ga/ga4/).
 
-This section contains information on how to:
+This section contains information on:
 
-- [understand the GOV.UK GA4 data](/analysis/govuk-ga4/understand-ga4/)
-- [use the GOV.UK GA4 data in various tools](/analysis/govuk-ga4/use-ga4/)
+- [what information you can get from the GOV.UK GA4 data](/analysis/govuk-ga4/ga4-data-information/)
+- [understanding the GOV.UK GA4 data structure](/analysis/govuk-ga4/understand-ga4/)
+- [using the GOV.UK GA4 data in various tools](/analysis/govuk-ga4/use-ga4/)

--- a/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
@@ -1,11 +1,11 @@
 ---
-title: Understand the GOV.UK GA4 data
-weight: 1
-last_reviewed_on: 2024-02-27
+title: Understand the GOV.UK GA4 data structure
+weight: 2
+last_reviewed_on: 2024-03-25
 review_in: 6 months
 ---
 
-# Understand the GOV.UK GA4 data
+# Understand the GOV.UK GA4 data structure
 <span style="color:red">This page is a work in progress.</span>
 
 This page contains information on the different events being captured as part of the GOV.UK GA4 implementation.

--- a/source/analysis/govuk-ga4/use-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/use-ga4/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use the GOV.UK GA4 data
-weight: 2
+weight: 3
 last_reviewed_on: 2024-02-26
 review_in: 6 months
 ---

--- a/source/data-sources/ga/ga4-flat/index.html.md.erb
+++ b/source/data-sources/ga/ga4-flat/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GA4 flattened tables
 weight: 3
-last_reviewed_on: 2024-02-19
+last_reviewed_on: 2024-03-25
 review_in: 6 months
 ---
 
@@ -165,7 +165,7 @@ The code is exectuted via Dataform every morning at 8am UTC and it is stored in 
 | viewport_size | STRING | NULLABLE | The size of the browser window, minus the scroll bars and toolbars |
 | batch_page_id | INTEGER | NULLABLE | |
 | batch_ordering_id | INTEGER | NULLABLE | |
-| timestamp | INTEGER | NULLABLE | The [Unix timestamp](https://docs.publishing.service.gov.uk/analytics/attribute_timestamp.html). This is a custom dimension, pushed with every dataLayer event, unlike the default event_timestamp above |
+| timestamp | INTEGER | NULLABLE | The [Unix timestamp](https://docs.publishing.service.gov.uk/analytics/attribute_timestamp.html) in milliseconds. This is a custom dimension, pushed with every dataLayer event, unlike the default event_timestamp above |
 | copy_length | INTEGER | NULLABLE | The number of characters in text copied ([copy events](https://docs.publishing.service.gov.uk/analytics/event_copy.html) only) |
 | item_list_name | STRING | NULLABLE | The name of the item list - on GOV.UK, this will be the name of a finder (search/search results) page |
 | item_id | STRING | NULLABLE | The URL of the search result item. A maximum of 200 search result items (the first 200) will be sent on longer search results pages |

--- a/source/data-sources/ga/ga4/index.html.md.erb
+++ b/source/data-sources/ga/ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4
 weight: 1
-last_reviewed_on: 2024-02-27
+last_reviewed_on: 2024-03-25
 review_in: 6 months
 ---
 
@@ -11,6 +11,8 @@ Google Analytics 4 is used to collect data on the usage of GOV.UK.
 This data can be accessed via the Google Analytics 4 user interface, the GA4 Looker Studio connection, and the Google Analytics Data API.
 
 This data is also exported to [BigQuery](/data-sources/ga/ga4-bq/).
+
+Information on how to understand and use this data can be found in the [Analysis section of this site](/analysis/govuk-ga4/).
 
 ## Access
 All GDS staff should have 'Analyst' level access to the data. If you have any issues accessing the data, please contact the Analytics team.


### PR DESCRIPTION
Some small tweaks/updates to the existing GOV.UK GA4 documentation plus a new page for some of Tim's work summarising what you can learn from the GOV.UK GA4 data for those less familiar (linked to this card: https://trello.com/c/2snhT4zc/100-write-ga4-end-user-document-answering-the-question-what-data-can-you-see-about-a-page)