### PR TITLE
Hiding old analysis pages

### DIFF
--- a/source/analysis/abmv/index.html.md.erb
+++ b/source/analysis/abmv/index.html.md.erb
@@ -3,6 +3,7 @@ title: A/B and multivariate testing
 weight: 47
 last_reviewed_on: 2022-05-12
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # A/B and multivariate testing

--- a/source/analysis/access-publishing/index.html.md.erb
+++ b/source/analysis/access-publishing/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the publishing database
 weight: 39
 last_reviewed_on: 2022-05-13
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use the GOV.UK publishing database

--- a/source/analysis/accessibility/index.html.md.erb
+++ b/source/analysis/accessibility/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the GOV.UK accessibility report runner
 weight: 35
 last_reviewed_on: 2022-09-15
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use the GOV.UK accessibility report runner

--- a/source/analysis/best-bets/index.html.md.erb
+++ b/source/analysis/best-bets/index.html.md.erb
@@ -3,6 +3,7 @@ title: Change search results on GOV.UK (best bets)
 weight: 36
 last_reviewed_on: 2021-09-09
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Change search results on GOV.UK (best bets)

--- a/source/analysis/content-store/index.html.md.erb
+++ b/source/analysis/content-store/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use GOV.UK Content Store database
 weight: 32
 last_reviewed_on: 2021-09-09
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use GOV.UK Content Store database

--- a/source/analysis/forward-path/index.html.md.erb
+++ b/source/analysis/forward-path/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the forward page path tool
 weight: 39.1
 last_reviewed_on: 2022-02-23
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Using the forward page path tool

--- a/source/analysis/intent-detector/baseline/index.html.md.erb
+++ b/source/analysis/intent-detector/baseline/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the baseline model
 weight: 39.62
 last_reviewed_on: 2022-03-04
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use the baseline model

--- a/source/analysis/intent-detector/index.html.md.erb
+++ b/source/analysis/intent-detector/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the GOV.UK intent detector
 weight: 39.6
 last_reviewed_on: 2022-03-04
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use the GOV.UK intent detector

--- a/source/analysis/intent-detector/iunis/assumptions-caveats/index.html.md.erb
+++ b/source/analysis/intent-detector/iunis/assumptions-caveats/index.html.md.erb
@@ -3,6 +3,7 @@ title: Assumptions and caveats
 weight: 6
 last_reviewed_on: 2022-03-25
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Assumptions and caveats

--- a/source/analysis/intent-detector/iunis/index.html.md.erb
+++ b/source/analysis/intent-detector/iunis/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the IUNIS algorithm
 weight: 39.61
 last_reviewed_on: 2022-03-04
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use the IUNIS algorithm

--- a/source/analysis/intent-detector/iunis/page-access-weight-matrix/index.html.md.erb
+++ b/source/analysis/intent-detector/iunis/page-access-weight-matrix/index.html.md.erb
@@ -3,6 +3,7 @@ title: Create the page access weight matrix
 weight: 2
 last_reviewed_on: 2022-03-25
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Create the page access weight matrix

--- a/source/analysis/intent-detector/iunis/page-term-idf-matrix/index.html.md.erb
+++ b/source/analysis/intent-detector/iunis/page-term-idf-matrix/index.html.md.erb
@@ -3,6 +3,7 @@ title: Create the page term TF-IDF matrix
 weight: 1
 last_reviewed_on: 2022-03-25
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Create the page term TF-IDF matrix

--- a/source/analysis/intent-detector/iunis/run-the-iunis/index.html.md.erb
+++ b/source/analysis/intent-detector/iunis/run-the-iunis/index.html.md.erb
@@ -3,6 +3,7 @@ title: Run the IUNIS algorithm
 weight: 5
 last_reviewed_on: 2022-03-25
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Run the IUNIS algorithm

--- a/source/analysis/intent-detector/iunis/step-function-alpha-vector/index.html.md.erb
+++ b/source/analysis/intent-detector/iunis/step-function-alpha-vector/index.html.md.erb
@@ -3,6 +3,7 @@ title: Create the step function alpha vector
 weight: 3
 last_reviewed_on: 2022-03-25
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Create the step-function alpha-values vector

--- a/source/analysis/intent-detector/iunis/topology-matrix/index.html.md.erb
+++ b/source/analysis/intent-detector/iunis/topology-matrix/index.html.md.erb
@@ -3,6 +3,7 @@ title: Create the topology matrix
 weight: 4
 last_reviewed_on: 2022-03-25
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Create the topology matrix

--- a/source/analysis/intent-detector/performance-analyst/index.html.md.erb
+++ b/source/analysis/intent-detector/performance-analyst/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the performance analyst model
 weight: 39.63
 last_reviewed_on: 2022-03-04
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use the performance analyst model

--- a/source/analysis/mirror/index.html.md.erb
+++ b/source/analysis/mirror/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use GOV.UK mirror
 weight: 34
 last_reviewed_on: 2021-09-09
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use GOV.UK mirror

--- a/source/analysis/pogostick/index.html.md.erb
+++ b/source/analysis/pogostick/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the pogo-sticking dashboards
 weight: 39.4
 last_reviewed_on: 2022-02-23
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Using the pogo-sticking dashboards

--- a/source/analysis/pogostick/main/index.html.md.erb
+++ b/source/analysis/pogostick/main/index.html.md.erb
@@ -3,6 +3,7 @@ title: Using the main pogo-sticking dashboard
 weight: 39.41
 last_reviewed_on: 2022-02-23
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Using the main pogo-sticking dashboard

--- a/source/analysis/pogostick/smartanswer/index.html.md.erb
+++ b/source/analysis/pogostick/smartanswer/index.html.md.erb
@@ -3,6 +3,7 @@ title: Using the pogo-sticking between "smart answer clicked" pages dashboard
 weight: 39.43
 last_reviewed_on: 2022-02-23
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Using the pogo-sticking between ‘smart answer clicked’ pages dashboard

--- a/source/analysis/pogostick/tracking/index.html.md.erb
+++ b/source/analysis/pogostick/tracking/index.html.md.erb
@@ -3,6 +3,7 @@ title: Using the pogo-sticking dashboard page tracking dashboard
 weight: 39.42
 last_reviewed_on: 2022-02-23
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Using the pogo-sticking dashboard page tracking dashboard

--- a/source/analysis/related-links/index.html.md.erb
+++ b/source/analysis/related-links/index.html.md.erb
@@ -3,6 +3,7 @@ title: Understanding how the GOV.UK related links are generated
 weight: 34
 last_reviewed_on: 2022-10-6
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # How are GOV.UK related links generated?

--- a/source/analysis/reverse-path/index.html.md.erb
+++ b/source/analysis/reverse-path/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the reverse page path tool
 weight: 39.2
 last_reviewed_on: 2022-02-23
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use the reverse page path tool

--- a/source/analysis/sagemaker/index.html.md.erb
+++ b/source/analysis/sagemaker/index.html.md.erb
@@ -3,6 +3,7 @@ title: Manage your machine's resources using AWS Sagemaker
 weight: 35
 last_reviewed_on: 2021-09-09
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Manage your machine's resources using AWS Sagemaker

--- a/source/analysis/spam-filter/index.html.md.erb
+++ b/source/analysis/spam-filter/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the GOV.UK feedback spam classifier
 weight: 48
 last_reviewed_on: 2022-07-26
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use the GOV.UK feedback spam classifier

--- a/source/analysis/spider-diagram/index.html.md.erb
+++ b/source/analysis/spider-diagram/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the spider diagram tool
 weight: 39.3
 last_reviewed_on: 2022-02-23
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use the spider diagram tool

--- a/source/analysis/use-publishing/index.html.md.erb
+++ b/source/analysis/use-publishing/index.html.md.erb
@@ -3,6 +3,7 @@ title: Use the publishing database
 weight: 41
 last_reviewed_on: 2022-05-03
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Use the GOV.UK publishing database


### PR DESCRIPTION
Hiding old analysis information pages from the navigation so that it is easier to find the new GA4 content (but not yet deleting anything whilst we determine what content is still useful)