### PR TITLE
Adding notes on GOV.UK GA4 naming conventions

### DIFF
--- a/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
@@ -284,6 +284,23 @@ Steps:
 A basic exploration showing the bounce rate on GOV.UK landing pages can be [found here](https://analytics.google.com/analytics/web/?pli=1#/analysis/p330577055/edit/yPJT7K_fRlmfQVv3ceb5JQ).
 
 
+## User and tech attributes
+
+There are a variety of dimensions available to help you understand the attributes of users using GOV.UK.
+
+### Device category
+
+The device category tells you whether a user was using a desktop, mobile, tablet, or other device to browse GOV.UK.
+
+#### Method in an exploration
+
+Steps:
+
+1. In an [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), create a table showing the 'Device category' dimension by the 'Sessions' metric
+2. If you are interested in the device categories used on specific pages, you could filter the data by the 'Page path and screen class' dimension to equal/contain the path of the specific pages you want. This would then tell you the devices used in each session that included a view of the selected page
+3. Change the date range and sort the table however you like
+
+
 ## Sorting and ordering data
 
 You can sort the data in your exploration by clicking on the value column headings you wish to sort the data by.

--- a/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
@@ -121,7 +121,22 @@ ORDER BY
 
 File downloads will have the event name ‘file_download’. 
 
+### File downloads of a given file
+
+You can count downloads of a file, regardless of which page the file was downloaded on, by using the file_download event and Link URL.
+
+#### Method in an exploration
+
+Steps:
+
+1. In a free form exploration, create a table showing the ‘Link URL’ dimension by the ‘Event count’ metric. Alternatively, you could add in the ‘Page path and screen class’ dimension to show you which pages your file is downloaded from, or the 'Link text' dimension to show you which text is clicked to download your file 
+2. Filter the data by the ‘Event name’ dimension to equals/contains ‘file_download’. This selects the file_download event which fires when the user clicks on a link to download a file
+3. Filter the data by the ‘Link URL’ dimension to equal the URL of the specific file you want to find downloads of
+4. Sort the table however you like
+
 ### File downloads on a given page
+
+You can find all file downloads from a given page by using the file_download event and filtering to the desired page path.
 
 #### Method in an exploration
 
@@ -129,7 +144,7 @@ Steps:
 
 1. In a free form exploration, create a table showing the ‘Link text’ or ‘Link URL’ dimension by the ‘Event count’ metric
 2. Filter the data by the ‘Event name’ dimension to equals/contains ‘file_download’. This selects the file_download event which fires when the user clicks on a link to download a file
-3. Filter the data by the ‘Page path and screen class’ dimension to equal the path of the specific page you want link clicks from. The ‘page path’ is the part of the URL after the hostname (not including any query strings) of a page, so by using it here we are selecting the page the user clicked the link on
+3. Filter the data by the ‘Page path and screen class’ dimension to equal the path of the specific page you want downloads from. The ‘page path’ is the part of the URL after the hostname (not including any query strings) of a page, so by using it here we are selecting the page the user clicked the download link on
 4. Sort the table however you like
 
 #### Method in BigQuery

--- a/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
@@ -36,7 +36,7 @@ The ‘page path’ is the part of the URL after the hostname (not including any
 
 Steps:
 
-1. In a free form exploration, create a table showing the ‘Page path and screen class’ dimension and the ‘Views’ metric
+1. In an [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), create a table showing the ‘Page path and screen class’ dimension and the ‘Views’ metric
 2. If you would like to only look at page view data for certain pages, filter the data using the ‘Page path’ dimension to select the paths of the pages you are interested in.  For example, if you were only interested in ‘browse’ pages on GOV.UK, you could filter down to Page path contains ‘/browse’
 3. Change the date range and sort the table however you like
 
@@ -82,7 +82,7 @@ These events should all have dimensions such as the ‘Link URL’, ‘Link text
 
 Steps:
 
-1. In a free form exploration, create a table showing the ‘Link text’ or ‘Link URL’ dimension by the ‘Event count’ metric
+1. In an [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), create a table showing the ‘Link text’ or ‘Link URL’ dimension by the ‘Event count’ metric
 2. Filter the data by the ‘Event name’ dimension to equals/contains ‘navigation’. This selects the navigation event which fires when the user clicks a link
 3. Filter the data by the ‘Outbound’ dimension to equals/contains ‘true’. This selects link clicks away from GOV.UK
 4. Filter the data by the ‘Page path and screen class’ dimension to equal the path of the specific page you want link clicks from. The ‘page path’ is the part of the URL after the hostname (not including any query strings) of a page, so by using it here we are selecting the page the user clicked the link on
@@ -129,7 +129,7 @@ You can count downloads of a file, regardless of which page the file was downloa
 
 Steps:
 
-1. In a free form exploration, create a table showing the ‘Link URL’ dimension by the ‘Event count’ metric. Alternatively, you could add in the ‘Page path and screen class’ dimension to show you which pages your file is downloaded from, or the 'Link text' dimension to show you which text is clicked to download your file 
+1. In an [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), create a table showing the ‘Link URL’ dimension by the ‘Event count’ metric. Alternatively, you could add in the ‘Page path and screen class’ dimension to show you which pages your file is downloaded from, or the 'Link text' dimension to show you which text is clicked to download your file 
 2. Filter the data by the ‘Event name’ dimension to equals/contains ‘file_download’. This selects the file_download event which fires when the user clicks on a link to download a file
 3. Filter the data by the ‘Link URL’ dimension to equal the URL of the specific file you want to find downloads of
 4. Sort the table however you like
@@ -142,7 +142,7 @@ You can find all file downloads from a given page by using the file_download eve
 
 Steps:
 
-1. In a free form exploration, create a table showing the ‘Link text’ or ‘Link URL’ dimension by the ‘Event count’ metric
+1. In an [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), create a table showing the ‘Link text’ or ‘Link URL’ dimension by the ‘Event count’ metric
 2. Filter the data by the ‘Event name’ dimension to equals/contains ‘file_download’. This selects the file_download event which fires when the user clicks on a link to download a file
 3. Filter the data by the ‘Page path and screen class’ dimension to equal the path of the specific page you want downloads from. The ‘page path’ is the part of the URL after the hostname (not including any query strings) of a page, so by using it here we are selecting the page the user clicked the download link on
 4. Sort the table however you like
@@ -192,7 +192,7 @@ A basic exploration containing search terms used on GOV.UK can be [found here](h
 
 Steps:
 
-1. In a free form exploration, create a table showing the ‘Search term’ dimension by the ‘Event count’ metric.
+1. In an [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), create a table showing the ‘Search term’ dimension by the ‘Event count’ metric.
 2. Filter the data by the ‘Event name’ dimension to equals/contains ‘select_item’. This selects the select_item event when a user clicks on a search result.
 3. Filter the data by the ‘Link URL’ dimension to equal the path of the specific destination page you want search terms to. The ‘Link URL’ is the link the user clicked on from the search results, so by using it here we are selecting the search destination page.
 4. Change the date range and sort the table however you like!
@@ -211,7 +211,7 @@ There are a couple of different ways that this can be done with the GA4 data.
 
 Steps:
 
-1. In a free form exploration, create a table showing the ‘Search term’ dimension by the ‘Event count’ metric
+1. In an [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), create a table showing the ‘Search term’ dimension by the ‘Event count’ metric
 2. Filter the data by the ‘Event name’ dimension to equals/contains ‘search’. This selects the search event which fires when a user searches
 3. Filter the data by the ‘Page path and screen class’ dimension to equal the path of the specific page you want search terms from. The ‘page path’ is the part of the URL after the hostname (not including any query strings) of a page, so by using it here we are selecting the page the user searched on
 4. Change the date range and sort the table however you like
@@ -224,7 +224,7 @@ For an example in Looker Studio, see the ‘Top searches from these pages’ tab
 
 Steps:
 
-1. In a free form exploration, create a table showing the ‘Search term’ dimension by the ‘Event count’ metric
+1. In an [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), create a table showing the ‘Search term’ dimension by the ‘Event count’ metric
 2. Filter the data by the ‘Event name’ dimension to equals/contains ‘view_item_list’. This selects the view_item_list event which fires on views of search results lists
 3. Filter the data by the ‘Page referrer’ dimension to equal the specific page you want search terms from. The ‘page referrer’ is the page which led the user to their present page, so by using it here we are selecting the page before the search results
 4. Change the date range and sort the table
@@ -277,7 +277,7 @@ Although GA does not prevent you from adding bounce rate to such reports, the fi
 
 Steps:
 
-1. In a free form exploration, create a table showing the ‘Landing page + query string’ dimension by the ‘Bounce rate’ metric
+1. In an [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), create a table showing the ‘Landing page + query string’ dimension by the ‘Bounce rate’ metric
 2. If you are interested in the bounce rates for specific pages, filter the data by the ‘Landing page + query string’ dimension to equal/contain the path of the specific pages you want. The ‘Landing page + query string dimension’ only uses the path and query string - the part of the URL after the hostname
 3. Change the date range and sort the table however you like
 

--- a/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
@@ -115,18 +115,21 @@ These events are:
 
 ## GOV.UK GA4 naming conventions 
 
-There are a number of common naming conventions followed in the GOV.UK GA4 data. 
+There are a number of common naming conventions used in the GOV.UK GA4 data. 
+These rules are followed to make the data cleaner and easier to understand, and to reduce potential issues stemming from [high cardinality dimensions](https://support.google.com/analytics/answer/13331684). 
+Some of these are broader GA4 conventions, and some are GOV.UK-specific. 
 
-Some of these are broader GA4 conventions, and some are GOV.UK-specific.
 
-| Field | Rule | Notes |
-| --- | --- | --- | 
-| event_name | Event name is lowercase, with underscores separating words | Following wider [GA4 event naming rules](https://support.google.com/analytics/answer/13316687) | 
-| type | Type is lowercase, with spaces separating words | GOV.UK specific, to tidy the data and reduce cardinality | 
-| action | Action is lowercase, with spaces separating words | GOV.UK specific, to tidy the data and reduce cardinality | 
-| method | Method is lowercase, with spaces separating words | GOV.UK specific, to tidy the data and reduce cardinality | 
-| search term | Search term is lowercase, with spaces separating words and special characters and extra spaces removed | GOV.UK specific, to tidy the data and reduce cardinality | 
-| percent_scrolled | Percentage as a whole number, without a percent symbol | Matching standard [GA4 'enhanced measurement' data collection](https://support.google.com/analytics/answer/9143382?sjid=12324858776558292368-EU#general) | 
+This table details some of these conventions:
+
+| GA4 field name | Parameter name | Rule | Notes |
+| --- | --- | --- | --- | 
+| Event name | event_name | Event name is lowercase, with underscores separating words | Following wider [GA4 event naming rules](https://support.google.com/analytics/answer/13316687) | 
+| Type | type | Type is lowercase, with spaces separating words | GOV.UK specific, to tidy the data and reduce cardinality | 
+| Action | action | Action is lowercase, with spaces separating words | GOV.UK specific, to tidy the data and reduce cardinality | 
+| Method | method | Method is lowercase, with spaces separating words | GOV.UK specific, to tidy the data and reduce cardinality | 
+| Search term | search_term | Search term is lowercase, with spaces separating words and special characters and extra spaces removed | GOV.UK specific, to tidy the data and reduce cardinality | 
+| Per cent scrolled | percent_scrolled | Percentage as a whole number, without a percent symbol | Matching standard [GA4 'enhanced measurement' data collection](https://support.google.com/analytics/answer/9143382?sjid=12324858776558292368-EU#general) | 
 
 
 GA4 imposes a number of [limits on data collection](https://support.google.com/analytics/answer/9267744), such as on the lengths of field names and values, which also impact the data collected. 

--- a/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Understand the GOV.UK GA4 data structure
 weight: 2
-last_reviewed_on: 2024-05-01
+last_reviewed_on: 2024-05-08
 review_in: 6 months
 ---
 
@@ -111,3 +111,22 @@ These events are:
 
 - `view_item_list` events: fire on views of search results pages
 - `select_item` events: fire when a user clicks on a search result
+
+
+## GOV.UK GA4 naming conventions 
+
+There are a number of common naming conventions followed in the GOV.UK GA4 data. 
+
+Some of these are broader GA4 conventions, and some are GOV.UK-specific.
+
+| Field | Rule | Notes |
+| --- | --- | --- | 
+| event_name | Event name is lowercase, with underscores separating words | Following wider [GA4 event naming rules](https://support.google.com/analytics/answer/13316687) | 
+| type | Type is lowercase, with spaces separating words | GOV.UK specific, to tidy the data and reduce cardinality | 
+| action | Action is lowercase, with spaces separating words | GOV.UK specific, to tidy the data and reduce cardinality | 
+| method | Method is lowercase, with spaces separating words | GOV.UK specific, to tidy the data and reduce cardinality | 
+| search term | Search term is lowercase, with spaces separating words and special characters and extra spaces removed | GOV.UK specific, to tidy the data and reduce cardinality | 
+| percent_scrolled | Percentage as a whole number, without a percent symbol | Matching standard [GA4 'enhanced measurement' data collection](https://support.google.com/analytics/answer/9143382?sjid=12324858776558292368-EU#general) | 
+
+
+GA4 imposes a number of [limits on data collection](https://support.google.com/analytics/answer/9267744), such as on the lengths of field names and values, which also impact the data collected. 

--- a/source/processes/ga-access/index.html.md.erb
+++ b/source/processes/ga-access/index.html.md.erb
@@ -50,7 +50,7 @@ If a department does not have an Analytics SPOC in place, one can be [nominated]
 
 ### Public servants from organisations without access to SignOn
 
-SPOCs should contact the [Analytics team](/teams/analytics/) with details of user administration requets. 
+SPOCs should contact the [Analytics team](/teams/analytics/) with details of user administration requests. 
 
 ### Access request process diagram
 


### PR DESCRIPTION
Linked to https://trello.com/c/QCeYWJ23/233-add-documentation-on-govuk-ga4-naming-conventions, to support other GDS domains in mimicking GOV.UK data collection when migrating to GA4