### PR TITLE
Adding starter guide type info

### DIFF
--- a/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Find things in the GOV.UK GA4 data
 weight: 4
-last_reviewed_on: 2024-05-21
+last_reviewed_on: 2024-05-29
 review_in: 6 months
 ---
 
@@ -67,6 +67,24 @@ ORDER BY
   pageviews DESC
 ```
 
+
+### Page views filtered to a certain publishing organisation
+
+In GA4, there are two custom dimensions you can use to identify different organisations:
+
+1. Publishing organisations IDs, which uses the organisation codes. However, each document can be tagged to multiple organisations. These tags are added by publishers
+2. Primary publishing organisation. This is the long form official name of the organisation. Only one organisation can be added per document. The long text is used in this dimension to make reports more easily understandable to those who does not recognise the codes
+
+#### Method - using the views metric in an exploration
+
+Steps:
+
+1. Create a blank [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), and add in the ‘Page path and screen class’ and 'Primary publishing organsation' dimensions, along with the 'Views' metric, using the '+' buttons in the 'Variables' tab
+2. Add the ‘Page path and screen class’ dimension and the ‘Views’ metric to the table. You can do this by either dragging and dropping/selecting the 'Page path' dimension in the 'Rows' area in the 'Settings' tab, and doing the same to the 'Views' metric for the 'Values' area, or by just double-clicking on the dimension and metrics you want to use (they should automatically be assigned to be a row and a value in the table settings when you do this)
+2. Filter the data using the ‘Primary publishing organisation’ dimension to select the organisation you are interested in.  For example, if you were only interested in Home Office pages on GOV.UK, you could filter down to 'Primary publishing organisation' exactly matches ‘Home Office’
+3. Change the date range and sort the table however you like
+
+Remember to check the [data quality icons](https://support.google.com/analytics/answer/12856703?hl=en) when using reports or explorations in GA, and to keep an eye open for the impact of our high cardinality data in Looker Studio.
 
 ## Navigation (link clicks)
 
@@ -306,3 +324,10 @@ Steps:
 
 You can sort the data in your exploration by clicking on the value column headings you wish to sort the data by.
 
+## Using regex
+
+Regular expressions are very useful as they can help you create filters with more flexible definitions. 
+For example, if you wanted to find all pages with a document type of either 'taxon' or 'topic', you could do this using the pipe character (|), which specifes an OR condition - so 'taxon|topic' means 'taxon OR topic' and will select pages with either document type.
+
+[Google's documentation](https://support.google.com/analytics/answer/1034324) lists the metacharacters that can be used in regular expressions within Google Analytics. 
+Note that the default regex behaviour in GA4 is 'full match', so the data must exactly match the pattern you provide.

--- a/source/analysis/govuk-ga4/getting-started/index.html.md.erb
+++ b/source/analysis/govuk-ga4/getting-started/index.html.md.erb
@@ -1,0 +1,50 @@
+---
+title: Getting started with GA4
+weight: 1
+last_reviewed_on: 2024-05-29
+review_in: 6 months
+---
+
+# Getting started with GA4
+<span style="color:red">This page is a work in progress.</span>
+
+The [GOV.UK Google Analytics 4 (GA4) data](/data-sources/ga/ga4/) contains a variety of information on users of GOV.UK, and how those users interacted with various pages on GOV.UK.
+
+## How to login
+
+The GOV.UK GA4 interface can be found at https://analytics.google.com/analytics/web/#/p330577055/reports/intelligenthome.
+
+If you are not logged in to your Google account when trying to open the above link, Google will prompt you to log in. 
+You will have to log in using a Google account which has been granted access to GOV.UK GA4 data in order to be able to access the GOV.UK GA4 interface.
+
+## Google Analytics interface navigation
+
+The interface may not be the best tool to explore the data, depending on your needs, but it's still useful to know how to navigate it.
+
+Google provide some guidance on how to [find your way around GA4](https://support.google.com/analytics/answer/9367631) which may help understand the basics.
+
+If you use both GOV.UK's analytics and another account's analytics interface (for example, if you also use GA4 data collected by your department or on Blogs or Campaigns sites) you will want to know how to navigate between these different accounts and properties.
+This can be done using the menu opened by clicking on the current property's name in the top-left corner of the interface, between the analytics logo and the search bar.
+In this menu you should find all of the Analytics accounts and properties you have permissions to access. 
+
+Within each property, the 'Explore' section will probably be of particular interest to most data users, as this is where you can build custom tables to analyse the data.
+This can be accessed via the left-hand navigation pane.
+
+## How to use GA4 data
+
+Other guidance in this section will help you understand more about [what you can learn from GOV.UK's GA4 data](/analysis/govuk-ga4/ga4-data-information/) and how you can [find specific pieces of information in the data](/analysis/govuk-ga4/find-in-ga4/).
+
+Explorations are likely to be one of the most useful tools for most users analysing GOV.UK GA4 data.
+Guidance on using explorations is available in [Google's support documentation](https://support.google.com/analytics/answer/7579450), and some best practice advice is available on the page on [Google Analytics 4 user interface best practice](/analysis/govuk-ga4/use-ga4/ga4-interface/).
+
+There is also some best practice worth bearing in mind when working with the data in other tools, and this can be found in our [best practice guidance](/analysis/govuk-ga4/use-ga4/).
+
+## Sharing GA4 data and reports
+
+You can export data from reports and explorations by downloading to PDF, CSV, or exporting to Google Sheets. 
+Explorations can also be shared with others within the interface, by clicking to 'Share exploration' in the top-right corner.
+Explorations can only be shared in read-only mode; others will have to duplicate your exploration if they wish to make changes.
+
+You can also use the GA4 data in Looker Studio or other visualisation tools, and then share those reports with others.
+
+

--- a/source/analysis/govuk-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Understand and use the GOV.UK GA4 data
 weight: 31
-last_reviewed_on: 2024-03-27
+last_reviewed_on: 2024-05-29
 review_in: 6 months
 ---
 
@@ -13,6 +13,7 @@ More information about the different GOV.UK GA4 data sources can be found on the
 
 This section contains information on:
 
+- [getting started with GA4](/analysis/govuk-ga4/getting-started/)
 - [what information you can get from the GOV.UK GA4 data](/analysis/govuk-ga4/ga4-data-information/)
 - [understanding the GOV.UK GA4 data structure](/analysis/govuk-ga4/understand-ga4/)
 - [understanding the differences between GOV.UK UA and GA4 data](/analysis/govuk-ga4/understand-ua-differences/)

--- a/source/analysis/govuk-ga4/understand-ua-differences/index.html.md.erb
+++ b/source/analysis/govuk-ga4/understand-ua-differences/index.html.md.erb
@@ -124,6 +124,14 @@ Sampling and [high cardinality dimensions](https://support.google.com/analytics/
 
 GA4 brings with it a new Google Analytics interface, featuring new tools such as [explorations](https://analytics.google.com/analytics/web/?pli=1#/analysis/p330577055).
 
+### Default regex behavior
+
+One difference that you should bear in mind when using reports or explorations in GA4, or using GA4 data in Looker Studio, is that the default regex behaviour has changed with GA4.
+
+As detailed in Google's documentation, in UA the default behaviour was 'partial match', so an expression used would be true if the pattern provided was contained anywhere in the data.
+
+In GA4, the default behaviour is 'full match', so the data must exactly match the pattern provided.
+
 
 ## Which is better or correct - UA or GA4?
 

--- a/source/analysis/govuk-ga4/use-ga4/ga4-interface/index.html.md.erb
+++ b/source/analysis/govuk-ga4/use-ga4/ga4-interface/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Google Analytics 4 user interface best practice
 weight: 1
-last_reviewed_on: 2024-04-23
+last_reviewed_on: 2024-05-29
 review_in: 6 months
 ---
 
@@ -14,7 +14,9 @@ If you do not have access to this, please follow the [GOV.UK GA access process](
 
 In the GA4 interface, you can inspect the data using [reports](https://support.google.com/analytics/answer/9212670) and [explorations](https://support.google.com/analytics/answer/7579450).
 
-### GA4 interface best practice
+## GA4 interface best practice
+
+### Pay attention to data quality 
 
 Pay attention to the [data quality icons](https://support.google.com/analytics/answer/12856703) which can be found throughout the GA4 interface.
 These indicate whether the data in question is [sampled](https://support.google.com/analytics/answer/13331292), has [thresholding](https://support.google.com/analytics/answer/9383630) applied, or is affected by [cardinality](https://support.google.com/analytics/answer/12226705).
@@ -25,3 +27,17 @@ In most cases, if you select ‘More detailed results’ in the dropdown, you wi
 Be particularly careful when using same-day data.
 GA4 data on GOV.UK [takes several hours to be processed](https://support.google.com/analytics/answer/12233314?hl=en&ref_topic=13818299&sjid=14243600463504287898-EU), so same-day data is often very unreliable.
 It is usually better to set your date range to exclude today's data, unless there is a specific reason you need to look at today.
+
+### Name things sensibly
+
+Assets shared within the interface are shared with all users of the property (so, all public servants with access to the GOV.UK GA4 data).
+It is therefore advisable to give any reports and explorations created clear and sensible names.
+You may wish to include your organisation's acronym if you want others you work with to be able to find your explorations easily.
+
+You can find explorations you have previously created easily by clicking the dropdown on the 'Owner' field (which appears when you hover over 'Owner') and selecting 'Owned by me'.
+You can also search for explorations using the search feature on the top-right of the table of explorations, and you can sort them by name and modification time.
+
+### Deleted unusued shared assets you have created
+
+It is requested that you delete any shared explorations you have created when they are no longer of use.
+This is to help declutter the shared workspace.


### PR DESCRIPTION
Adding GA4 'starter guide' type info (to cover the similar information we shared on UA). Linked to https://trello.com/c/YdvBa0he/241-adapt-gds-ga-starter-guide-content-for-ga4-and-publish-to-data-docs