### PR TITLE
Notes related to end of Early Access group

### DIFF
--- a/source/data-sources/ga/ga4/index.html.md.erb
+++ b/source/data-sources/ga/ga4/index.html.md.erb
@@ -1,12 +1,12 @@
 ---
 title: GOV.UK GA4
 weight: 1
-last_reviewed_on: 2024-05-23
+last_reviewed_on: 2024-06-04
 review_in: 6 months
 ---
 
 # GOV.UK GA4
-Google Analytics 4 is used to collect data on the usage of GOV.UK.
+Google Analytics 4 (GA4) is used to collect data on the usage of GOV.UK.
 
 This data can be accessed via the Google Analytics 4 user interface, the GA4 Looker Studio connection, and the Google Analytics Data API.
 
@@ -16,9 +16,11 @@ Information on how to understand and use this data can be found in the [Analysis
 
 ## Content
 
-Data first started being collected into this property on 23/09/22. 
-
+Data was first collected into this property on 23/09/22.
 The events captured have changed significantly over time, and so early data quality may be patchy. 
+
+Data is collected from dataLayer pushes using [Google Tag Manager](/processes/gtm/), which applies any appropriate transformations to the data and then sends it to GA4.
+More information on the dataLayer pushes implemented on GOV.UK can be found in the [Implementation record](https://docs.publishing.service.gov.uk/analytics/events.html).
 
 ## Access
 All GDS staff should have 'Analyst' level access to the data. If you have any issues accessing the data, please contact the Analytics team.
@@ -67,3 +69,8 @@ If you spot any PII or other data that should not be present in the GA4 datasets
 ### Retention
 
 A data retention period for this data is set in the GA4 user interface. For the integration, staging, and production GOV.UK sites, this is set to 38 months.
+
+## Governance
+
+The collection, storage, and use of this data is governed by a Data Protection Impact Assessment (DPIA). 
+Public servants interested in this DPIA can request a copy from the [GOV.UK Analytics team](/teams/analytics/).

--- a/source/processes/gtm/index.html.md.erb
+++ b/source/processes/gtm/index.html.md.erb
@@ -1,12 +1,12 @@
 ---
 title: Google Tag Manager
 weight: 3
-last_reviewed_on: 2024-04-25
+last_reviewed_on: 2024-06-04
 review_in: 6 months
 ---
 
 # Google Tag Manager
-Google Tag Manager (GTM) is the method we use to deploy GA4 tracking to www.gov.uk.
+Google Tag Manager (GTM) is used on www.gov.uk to send data to [Google Analytics 4](/data-sources/ga/ga4/).
 
 The deployment and administration of GTM is owned by the [GOV.UK Analytics team](/teams/analytics/).
 
@@ -15,11 +15,12 @@ See [the GTM change process](https://docs.publishing.service.gov.uk/manual/gtm-c
 ## Access
 Read access is granted to Performance Analysts to allow for debugging and checking analytics data.
 
-Edit access will be limited to those who need it for development and debugging.
+Edit access is limited to those who need it for development and debugging.
 This will be Performance Analysts in the Analytics team.
 
-Approve has limited use in GOV.UK and not used.
-
-Publish access is limited to developers activily working on Analytics and those who cover support.
+Publish access is limited to developers activily working on Analytics and those who cover support, as well as certain Performance Analysts in the Analytics team.
 
 Note that Approve and Publish permissions can not be assigned to groups, only individuals.
+
+We are happy to share a copy of our GOV.UK GTM container with any interested public servants.
+Please get in touch with the [GOV.UK Analytics team](/teams/analytics/) who will be able to grant you access in GTM or send you a copy of the JSON file.

--- a/source/tools/google-cloud-platform/gcp-projects/index.html.md.erb
+++ b/source/tools/google-cloud-platform/gcp-projects/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Google Cloud Platform projects
 weight: 2
-last_reviewed_on: 2024-04-24
+last_reviewed_on: 2024-06-04
 review_in: 6 months
 ---
 
@@ -37,18 +37,6 @@ The quotas are 1TB per user per day and a global limit of 3TB per day.
 </details>
 </span>
 
-## GA4 early access
-
-<span>
-<details>
-<summary>[This project](https://console.cloud.google.com/welcome?project=ga4-early-access) is used to enable access to our GA4 data to other government departments while monitoring costs and access.</summary>
-
-There are quotas set up on this project to limit the amount of BigQuery data that can be queried, this is to provide a safety net for analysts and to protect the organisation from run away costs.
-
-The quotas are 1TB per user per day and a global limit of 3TB per day.
-
-</details>
-</span>
 
 ## GDS BigQuery reporting
 


### PR DESCRIPTION
Notes related to end of Early Access group, linked to https://trello.com/c/VqJ7vWio/214-agree-approach-to-transitioning-away-from-the-early-access-group