### PR TITLE
Adding information on historic UA data access and use

### DIFF
--- a/source/analysis/content-data/index.html.md.erb
+++ b/source/analysis/content-data/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use the Content Data app
-weight: 32
+weight: 33
 last_reviewed_on: 2024-05-16
 review_in: 6 months
 ---

--- a/source/analysis/ga-ua-data/index.html.md.erb
+++ b/source/analysis/ga-ua-data/index.html.md.erb
@@ -1,0 +1,391 @@
+---
+title: Use the historic analytics (UA) data
+weight: 32
+last_reviewed_on: 2024-06-28
+review_in: 6 months
+---
+
+# Use the historic analytics (UA) data
+<span style="color:red">This page is a work in progress.</span>
+
+Before [Google Analytics 4](/analysis/govuk-ga4/), we used Universal Analytics (UA) to collect data on the usage of various government sites, including GOV.UK.
+
+More information on the data sources themselves can be found on the [historic UA data sources page](/data-sources/historic-ua/).
+
+## Get access to UA data
+
+For information on how to get access to the historic UA data, please see the [historic data access policy](/processes/ga-historic/).
+
+## How to use the UA data
+
+The historic UA data can be queried directly in [BigQuery](/tools/google-cloud-platform/bigquery/), or it can be used in various reporting or data visualisation tools.
+
+Whether you query it directly in BigQuery or use the data in a reporting tool, you will need a Google Cloud Platform project with billing enabled through which you can query the data.
+If you are GDS staff, please contact the #data-engineering community who will be able to provide you with a Google Cloud Platform billing project ID.
+If you work for another public sector organisation, your department or organisation will have to provide you with this ID. 
+We are investigating potential solutions for public sector organisations who do not have access to Google Cloud Platform, so please do get in touch with the Analytics team via the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk) if you have any issues.
+
+If you are using the GOV.UK historic data, we recommend you use the [flattened dataset](/data-sources/ga/ua-flat/) as this is cheaper and easier to query.
+
+
+### Use the UA data in Looker Studio
+
+The UA data stored in BigQuery can be used in Looker Studio.
+
+To connect to the UA data, we recommend you use a custom query. You can do this by:
+
+1. Clicking to [add a data source](https://support.google.com/looker-studio/answer/6300774?hl=en) 
+2. In the ‘Connect to data’ panel, selecting ‘BigQuery’
+3. In the left-hand menu, selecting ‘Custom query’
+4. Entering your Google Cloud Platform billing project ID
+5. Entering a query to select the fields needed using a WHERE statement to define the date range required
+6. Tick the checkbox to ‘enable date range parameters’ if needed
+7. Selecting ‘Add’ 
+
+
+An example of a generic SQL query that could be used in step 5 above is: 
+
+```SQL
+SELECT * 
+FROM `govuk-bigquery-analytics.FlattenedDailyData.flattened_daily_ga_data_*`
+WHERE _TABLE_SUFFIX BETWEEN @DS_START_DATE AND @DS_END_DATE
+```
+
+This query selects all fields from the [GOV.UK UA flattened tables](/data-sources/ga/ua-flat/) and returns all the data for those fields between the dates you have selected in your Looker Studio report.
+
+### Sample queries 
+
+Below are some sample queries which may help you in exploring the historic data.
+
+#### 'All pages' UA report query  
+
+The below query can be used to replicate the 'All Pages' report in the 'Site Content' section of the Behaviour reports in the Universal Analytics interface.
+This again uses the [GOV.UK UA flattened dataset](/data-sources/ga/ua-flat/) and Looker Studio date parameters, although these could easily be switched for dates in the 'YYYYMMDD' format.
+
+```SQL
+#Query to replicate the UA All Pages report
+#Page views and unique page views
+WITH
+PVS AS (
+SELECT
+  date,
+  pagePath,
+  COUNT(*) AS pageviews,
+  COUNT(DISTINCT session_id) AS unique_pageviews
+FROM (
+  SELECT
+    date,
+    pagePath,
+    CONCAT(fullVisitorId, CAST(visitStartTime AS STRING)) AS session_id
+  FROM
+    `govuk-bigquery-analytics.FlattenedDailyData.flattened_daily_ga_data_*`
+  WHERE
+    _table_suffix BETWEEN @DS_START_DATE
+    AND @DS_END_DATE
+    AND type = 'PAGE')
+GROUP BY
+  pagePath,
+  date
+ORDER BY
+  pageviews DESC ),
+#Average time on page
+ATOP AS (
+SELECT
+  date,
+  pagePath,
+  pageviews,
+  exits,
+  total_time_on_page,
+  CASE
+    WHEN pageviews = exits THEN 0
+    ELSE total_time_on_page / (pageviews - exits)
+END
+  AS avg_time_on_page
+FROM (
+  SELECT
+    date,
+    pagePath,
+    COUNT(*) AS pageviews,
+    SUM(
+    IF
+      (isExit IS NOT NULL, 1, 0)) AS exits,
+    SUM(time_on_page) AS total_time_on_page
+  FROM (
+    SELECT
+      date,
+      fullVisitorId,
+      visitStartTime,
+      pagePath,
+      hit_time,
+      type,
+      isExit,
+      CASE
+        WHEN isExit IS NOT NULL THEN last_interaction - hit_time
+        ELSE next_pageview - hit_time
+    END
+      AS time_on_page
+    FROM (
+      SELECT
+        date,
+        fullVisitorId,
+        visitStartTime,
+        pagePath,
+        hit_time,
+        type,
+        isExit,
+        last_interaction,
+        LEAD(hit_time) OVER (PARTITION BY fullVisitorId, visitStartTime ORDER BY hit_time) AS next_pageview
+      FROM (
+        SELECT
+          date,
+          fullVisitorId,
+          visitStartTime,
+          pagePath,
+          hit_time,
+          type,
+          isExit,
+          last_interaction
+        FROM (
+          SELECT
+            date,
+            fullVisitorId,
+            visitStartTime,
+            pagePath,
+            type,
+            isExit,
+            time / 1000 AS hit_time,
+            MAX(
+            IF
+              (isInteraction IS NOT NULL, time / 1000, 0)) OVER (PARTITION BY fullVisitorId, visitStartTime) AS last_interaction
+          FROM
+            `govuk-bigquery-analytics.FlattenedDailyData.flattened_daily_ga_data_*`
+          WHERE
+            _table_suffix BETWEEN @DS_START_DATE
+            AND @DS_END_DATE
+            AND type = 'PAGE'))
+      GROUP BY
+        date,
+        pagePath,
+        fullVisitorId,
+        visitStartTime,
+        hit_time,
+        type,
+        isExit,
+        last_interaction )
+    GROUP BY
+      date,
+      pagePath,
+      fullVisitorId,
+      visitStartTime,
+      hit_time,
+      type,
+      isExit,
+      last_interaction,
+      next_pageview)
+  GROUP BY
+    pagePath,
+    date
+  ORDER BY
+    pageviews DESC ) ),
+#Entrances
+ENTRANCES AS (
+SELECT
+  date,
+  pagePath,
+  SUM(entrances) AS entrances
+FROM (
+  SELECT
+    date,
+    pagePath,
+    CASE
+      WHEN isEntrance IS NOT NULL THEN 1
+      ELSE 0
+  END
+    AS entrances
+  FROM
+    `govuk-bigquery-analytics.FlattenedDailyData.flattened_daily_ga_data_*`
+  WHERE
+    _table_suffix BETWEEN @DS_START_DATE
+    AND @DS_END_DATE)
+GROUP BY
+  pagePath,
+  date
+ORDER BY
+  entrances DESC ),
+#Bounce rate
+BOUNCES AS (
+SELECT
+  date,
+  pagePath,
+  bounces,
+  sessions,
+  CASE
+    WHEN sessions = 0 THEN 0
+    ELSE bounces / sessions
+END
+  AS bounce_rate
+FROM (
+  SELECT
+    date,
+    pagePath,
+    SUM(bounces) AS bounces,
+    SUM(sessions) AS sessions
+  FROM (
+    SELECT
+      date,
+      fullVisitorId,
+      visitStartTime,
+      pagePath,
+      CASE
+        WHEN hitNumber = first_interaction THEN bounces
+        ELSE 0
+    END
+      AS bounces,
+      CASE
+        WHEN hitNumber = first_hit THEN visits
+        ELSE 0
+    END
+      AS sessions
+    FROM (
+      SELECT
+        date,
+        fullVisitorId,
+        visitStartTime,
+        pagePath,
+        bounces,
+        visits,
+        hitNumber,
+        MIN(
+        IF
+          (isInteraction IS NOT NULL, hitNumber, 0)) OVER (PARTITION BY fullVisitorId, visitStartTime) AS first_interaction,
+        MIN(hitNumber) OVER (PARTITION BY fullVisitorId, visitStartTime) AS first_hit
+      FROM
+        `govuk-bigquery-analytics.FlattenedDailyData.flattened_daily_ga_data_*`
+      WHERE
+        _table_suffix BETWEEN @DS_START_DATE
+        AND @DS_END_DATE
+      GROUP BY
+        fullVisitorId,
+        visitStartTime,
+        date,
+        pagePath,
+        bounces,
+        visits,
+        hitNumber,
+        isInteraction)
+    ORDER BY
+      sessions DESC )
+  GROUP BY
+    pagePath,
+    date) ),
+#Exits and exit rate
+EXITS AS (
+SELECT
+  date,
+  pagePath,
+  pageviews,
+  exits,
+  CASE
+    WHEN pageviews = 0 THEN 0
+    ELSE exits / pageviews
+END
+  AS exit_rate
+FROM (
+  SELECT
+    date,
+    pagePath,
+    COUNT(*) AS pageviews,
+    SUM(exits) AS exits
+  FROM (
+    SELECT
+      date,
+      pagePath,
+      CASE
+        WHEN isExit IS NOT NULL THEN 1
+        ELSE 0
+    END
+      AS exits
+    FROM
+      `govuk-bigquery-analytics.FlattenedDailyData.flattened_daily_ga_data_*`
+    WHERE
+      type = 'PAGE'
+      AND _table_suffix BETWEEN @DS_START_DATE
+      AND @DS_END_DATE)
+  GROUP BY
+    pagePath,
+    date))
+#Joining everything together
+SELECT
+PVS.date,
+PVS.pagePath AS page_path,
+PVS.pageviews,
+PVS.unique_pageviews,
+ATOP.avg_time_on_page,
+ATOP.total_time_on_page,
+ATOP.exits,
+ENTRANCES.entrances,
+BOUNCES.bounces,
+BOUNCES.sessions,
+BOUNCES.bounce_rate,
+EXITS.exit_rate
+FROM
+PVS
+JOIN
+ATOP
+ON
+PVS.pagePath = ATOP.pagePath
+AND PVS.date = ATOP.date
+JOIN
+EXITS
+ON
+PVS.pagePath = EXITS.pagePath
+AND PVS.date = EXITS.date
+JOIN
+ENTRANCES
+ON
+PVS.pagePath = ENTRANCES.pagePath
+AND PVS.date = ENTRANCES.date
+JOIN
+BOUNCES
+ON
+PVS.pagePath = BOUNCES.pagePath
+AND PVS.date = BOUNCES.date
+ORDER BY
+date DESC,
+pageviews DESC,
+unique_pageviews DESC
+```
+
+#### 'Top Events' UA report query  
+
+The below query can be used to replicate the 'Top Events' report in the 'Events' section of the Behaviour reports in the Universal Analytics interface.
+This uses the [GOV.UK UA raw dataset](/data-sources/ga/ua/), but this could easily be switched to use any raw UA dataset by changing the [dataset ID](/tools/google-cloud-platform/bigquery/#understanding-tables-datasets-and-projects).
+
+This query has the dates written in, although these could be switched for Looker Studio date parameters if used in a Looker Studio custom query (see the above queries for examples of this).
+
+```SQL
+SELECT
+  #Commenting out the date as it is not needed in the 'Top events' table, although it would be required for a chart of events over time
+  #date,
+  hits.eventInfo.eventCategory AS event_category,
+  hits.eventInfo.eventAction AS event_action,
+  hits.eventInfo.eventLabel AS event_label,
+  COUNT(*) AS total_events,
+  COUNT(DISTINCT CONCAT(CAST(fullVisitorId AS string), CAST(visitStartTime AS string))) AS unique_events,
+FROM
+  `govuk-bigquery-analytics.87773428.ga_sessions_*`,
+  UNNEST(HITS) AS HITS
+WHERE
+  _table_suffix BETWEEN '20240601'
+  AND '20240603'
+  AND totals.visits = 1
+  AND hits.type = 'EVENT'
+  AND hits.eventInfo.eventCategory IS NOT NULL
+GROUP BY
+  #date,
+  event_category,
+  event_action,
+  event_label
+ORDER BY
+  total_events DESC
+```

--- a/source/analysis/use-search-console/index.html.md.erb
+++ b/source/analysis/use-search-console/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use the GOV.UK Search Console data
-weight: 33
+weight: 34
 last_reviewed_on: 2024-06-08
 review_in: 6 months
 ---

--- a/source/data-sources/ga/ga4-logs/index.html.md.erb
+++ b/source/data-sources/ga/ga4-logs/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GA4 access logs
-weight: 6
+weight: 7
 last_reviewed_on: 2024-05-23
 review_in: 6 months
 ---

--- a/source/data-sources/ga/historic-ua/index.html.md.erb
+++ b/source/data-sources/ga/historic-ua/index.html.md.erb
@@ -25,8 +25,7 @@ There are several historic UA datasets. These include:
 To be granted access to this data, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
 
 ### Location
-Most of the various historic Google Analytics datasets are stored in BigQuery in the `gds-ga-archive` project.
-Any datasets currently stored in other projects and will be moved to the `gds-ga-archive` project in due course.
+Most of the GDS historic Google Analytics datasets are stored in BigQuery in the `gds-ga-archive` project.
 
 Information on the quotas applicable to this project can be found in the information on [GCP](/gcp/#gds-ga-archive).
 

--- a/source/data-sources/ga/historic-ua/index.html.md.erb
+++ b/source/data-sources/ga/historic-ua/index.html.md.erb
@@ -1,0 +1,34 @@
+---
+title: Historic analytics (Universal Analytics) data
+weight: 4
+last_reviewed_on: 2024-06-28
+review_in: 6 months
+---
+
+# Historic analytics (UA) data
+The previous version of Google Analytics, Universal Analytics, was sunset at the end of June 2024.
+Before this sunset, we exported several of our GOV.UK Universal Analytics properties' data and stored it in Google BigQuery.
+This data can be used for more long-term analysis.
+
+Guidance on how to use this can be found in the [analysis section](/analysis/ga-ua-data/).
+
+## Content
+
+There are several historic UA datasets. These include:
+
+- [UA data for www.gov.uk](/data-sources/ga/ua/)
+- UA data for the GOV.UK blog platform
+- UA data for goverment publishing apps and sites
+- UA data for other GDS-owned product sites
+
+## Access
+To be granted access to this data, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
+
+### Location
+Most of the various historic Google Analytics datasets are stored in BigQuery in the `gds-ga-archive` project.
+Any datasets currently stored in other projects and will be moved to the `gds-ga-archive` project in due course.
+
+Information on the quotas applicable to this project can be found in the information on [GCP](/gcp/#gds-ga-archive).
+
+## Schema
+The [UA BigQuery Export schema](https://support.google.com/analytics/answer/3437719?hl=en) defines the schema of these tables. 

--- a/source/data-sources/ga/ua-flat/index.html.md.erb
+++ b/source/data-sources/ga/ua-flat/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GOV.UK Universal Analytics flattened tables
-weight: 5
+weight: 6
 last_reviewed_on: 2024-05-23
 review_in: 6 months
 ---

--- a/source/data-sources/ga/ua/index.html.md.erb
+++ b/source/data-sources/ga/ua/index.html.md.erb
@@ -1,33 +1,28 @@
 ---
 title: GOV.UK Universal Analytics (BigQuery export)
-weight: 4
-last_reviewed_on: 2024-05-23
+weight: 5
+last_reviewed_on: 2024-06-28
 review_in: 6 months
 ---
 
 # GOV.UK Universal Analytics (BigQuery export)
-We export our GOV.UK Universal Analytics data and store it in Google BigQuery.
-This enables more detailed analysis and the use of GOV.UK UA data by other tools.
+From 2014 to 2024, we used Universal Analytics (UA) to collect analytics data on GOV.UK.
 
-Universal Analytics (UA) sends GOV.UK visitor journey data to the `govuk-bigquery-analytics.87773428.ga_sessions_intraday_YYYYMMDD` table 3 times a day, where:
+We are currently storing this historic GOV.UK Universal Analytics data in Google BigQuery.
+This enables detailed, long-term analysis and the use of GOV.UK UA data by other tools.
 
-- `govuk-bigquery-analytics` is the project ID
-- `87773428` is the dataset name
-- `ga_sessions_intraday_YYYYMMDD` is the table name
-- `YYYYMMDD` is the current date in year-month-day format
+## Content
 
-At the end of the day, Google automatically:
-
-- moves the data in this intraday table to a `ga_sessions_YYYYMMDD` table
-- deletes this intraday table
-- creates a new intraday table for the next day
-
+This dataset contains data collected between 2014 and June 2024.
 
 ## Access
 Everyone with a @digital.cabinet-office.gov.uk account (all GDS staff) has access to the data.
 
+Other public servants can request access to this data - see our [historic data policy](/processes/ga-historic/).
+
 ### Location
-This data is stored in BigQuery in the `govuk-bigquery-analytics.87773428` dataset. 
+This data is stored in BigQuery in the `govuk-bigquery-analytics.87773428` dataset.
+This dataset is made up of sharded tables, where each table is named `YYYYMMDD` after the date that data was collected on in year-month-day format.
 Like all of our data, this is located in the europe-west2 GCP region.
 
 For more information on our Google Cloud Platform projects, see our [GCP project documentation](/gcp/#universal-analytics).

--- a/source/processes/ga-historic/index.html.md.erb
+++ b/source/processes/ga-historic/index.html.md.erb
@@ -1,26 +1,28 @@
 ---
-title: Historic GA data
+title: Historic GA (UA) data
 weight: 7
-last_reviewed_on: 2024-02-13
+last_reviewed_on: 2024-06-28
 review_in: 6 months
-hide_in_navigation: true
 ---
 
 # Historic GA data
-<span style="color:red">**This page is a draft policy**</span>.
 
 Historic Google Analytics data is stored for a number of agreed GDS Universal Analytics properties.
+An inexhaustive list of these properties can be found on the [historic UA data sources page](/data-sources/ga/historic-ua/#content).
 This includes the [Universal Analytics data for www.gov.uk](/data-sources/ga/ua/).
 
+## What we provide access to
+Users are able to request access to:
+
+- Read access to the historic UA data in BigQuery, including any flattened/processed tables where available
+
+Departments are expected to pay for their queries via their own Google Cloud Project.
+
+For GDS staff, we have built a [Looker Studio report](https://lookerstudio.google.com/reporting/833939e2-2cfb-4ed3-a202-90498bf9daff/page/p_fg5xyapmid) which contains similar tables to some of the most frequently used reports in the UA interface.
+We are investigating ways to share reports with other public servants.
+
 ## Access
-Access to this historic data is currently heavily limited. 
-The access processes and policies for both GDS and cross-government users will be determined in the next few months.
+To be granted access to this data, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk), specifying which dataset you are interested in.
 
 Notice that we only provide read (data viewer) access to BigQuery.
-Departments are expected to pay for their own queries via their own Google Cloud Project.
-
-### Location
-The various historic Google Analytics datasets are primarily located in BigQuery in the `gds-ga-archive` project.
-Two datasets are currently stored in other projects and will be moved to the `gds-ga-archive` project in due course.
-
-Information on the quotas applicable to this project can be found in the information on [GCP](/gcp/#gds-ga-archive).
+Departments are expected to pay for their queries via their own Google Cloud Project.


### PR DESCRIPTION
Adding information on historic UA data access and use, linked to https://trello.com/c/Ilm6Xrnw/271-write-and-publish-guidance-on-how-to-use-the-govuk-ua-historic-data-in-bq