### PR TITLE
Tweaks to Content Data backfilling page

### DIFF
--- a/source/data-sources/content-data-app/content-data-processing/index.html.md.erb
+++ b/source/data-sources/content-data-app/content-data-processing/index.html.md.erb
@@ -1,15 +1,17 @@
 ---
-title: Content Data App Backfilling
+title: Content Data App backfilling
 weight: 1
-last_reviewed_on: 2024-06-25
+last_reviewed_on: 2024-06-28
 review_in: 6 months
 ---
 
-# Content Data App Backfilling
+# Content Data App backfilling
+
+This page contains information on checking and backfilling the Content Data app table in BigQuery.
 
 ## Data checking
 
-Sometime you may ned to check the volume of data on a given day. This can be done by running the following query.
+The following query may help you if you need to check the volume of data in the Content Data table by date.
 
 ```sql
 SELECT
@@ -22,14 +24,17 @@ ORDER BY
 1 DESC
 ```
 
-If any dates are missing, then there is no data and it will need backfilling.
+If any dates are missing, there is no data for that date and it will need backfilling.
 
 
 ## Backfilling
 
-The query to backfill content data is, you will need to change the YYYYMMDD to the date you need to back. You can also change this to a `BETWEEN` or `IN` statement.
+The below query will enable you to backfill the Content Data table ('GA4 dataform').
+You will need to change the 'YYYYMMDD' in this query to the date you need to query and append the data for.
+You can also change this to a `BETWEEN` or `IN` statement.
 
-The data should be appended to `govuk-content-data.ga4.GA4 dataform`. Once that is done you will have to notify #govuk-platform-support that the data is ready to reimport.
+The data should be appended to the `govuk-content-data.ga4.GA4 dataform` table.
+Once the data has been successfully appended (it is best to check this has worked using the query above) will have to notify #govuk-platform-support that the data is ready to reimport.
 
 
 
@@ -98,7 +103,7 @@ WITH
   FROM
     `ga4-analytics-352613.analytics_330577055.events_*`
   WHERE
-    _table_suffix = YYYYMMDD,
+    _table_suffix = YYYYMMDD ),
   CTE2 AS (
   SELECT
     the_date,

--- a/source/data-sources/content-data-app/content-data-processing/index.html.md.erb
+++ b/source/data-sources/content-data-app/content-data-processing/index.html.md.erb
@@ -34,7 +34,8 @@ You will need to change the 'YYYYMMDD' in this query to the date you need to que
 You can also change this to a `BETWEEN` or `IN` statement.
 
 The data should be appended to the `govuk-content-data.ga4.GA4 dataform` table.
-Once the data has been successfully appended (it is best to check this has worked using the query above) will have to notify #govuk-platform-support that the data is ready to reimport.
+
+Once the data has been successfully appended (it is best to check this has worked using the checking query above), you will have to notify #govuk-platform-support that the data is ready to reimport.
 
 
 


### PR DESCRIPTION
Tweaks to Content Data backfilling page. Mostly just intending to add in a bracket to the SQL after I noticed one was missing when doing some backfilling - https://trello.com/c/kwxc7XMG/273-fix-missing-content-data-dates-12th-and-17th-june - but I ended up doing some other copy-editing as well