### PR TITLE
Adding pages on blogs GA4

### DIFF
--- a/source/analysis/blogs-ga4/index.html.md.erb
+++ b/source/analysis/blogs-ga4/index.html.md.erb
@@ -1,0 +1,57 @@
+---
+title: Use the GOV.UK blogs GA4 data
+weight: 32
+last_reviewed_on: 2024-07-17
+review_in: 6 months
+---
+
+# Use the GOV.UK blogs GA4 data
+<span style="color:red">This page is a work in progress.</span>
+
+Google Analytics 4 (GA4) is used to collect data on the usage of the [GOV.UK blogs](https://www.blog.gov.uk/).
+
+More information about the different GOV.UK GA4 data sources can be found on the [GOV.UK GA4 data source pages](/data-sources/ga/blogs-ga4/).
+
+## Get access to GOV.UK blogs GA4 data
+
+Blog editors should be able to grant users access to the blogs GA4 property. 
+
+If you have any issues, please contact the [GOV.UK GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
+
+## How to use the GOV.UK blogs GA4 data
+
+The blogs GA4 data can be viewed in the GA4 interface, or it can be used in various reporting or data visualisation tools (such as Looker Studio).
+
+## Find things in the GOV.UK blogs GA4 data
+
+In Universal Analytics, we used 'views' to separate out the data associated with each blog site. 
+'Views' do not exist in GA4, so all of the data from all blogs is stored together.
+This will mean you will need to filter to the blog or blogs you are interested in to see only stats relevant to your blogs.
+
+### Page views by blog (hostname)
+
+There is a report in the GA4 interface which shows views by page path.
+In explorations and in Looker Studio, you can get numbers of page views either using a count of page_view events or using the ‘views’ metric.
+
+A count of page_view events in GA4 should provide you with a similar number to the total pageviews figure in Universal Analytics (UA).
+
+‘Unique pageviews’ no longer exists as a metric in GA4, but the ‘sessions’ metric is conceptually similar, telling you how many sessions contained a visit to this page.
+However, the definition of a session has changed in GA4, so the figures produced here will deviate significantly from those in UA.
+
+### Page views by hostname
+
+We recommend using ‘page path’ over the ‘page location’ as the 'page' dimension as ‘page location’ is compatible with fewer other dimensions.
+
+The ‘page path’ is the part of the URL after the hostname (not including any query strings) of a page.
+
+Steps in an exploration:
+
+1. Create a blank [exploration](https://analytics.google.com/analytics/web/#/analysis/p436727455), and add in the ‘Page path and screen class’ and 'Hostname' dimensions, along with the 'Views' metric, using the '+' buttons in the 'Variables' tab
+2. Add the ‘Page path and screen class’ dimension and the ‘Views’ metric to the table. You can do this by either dragging and dropping/selecting the 'Page path' dimension in the 'Rows' area in the 'Settings' tab, and doing the same to the 'Views' metric for the 'Values' area, or by just double-clicking on the dimension and metrics you want to use (they should automatically be assigned to be a row and a value in the table settings when you do this)
+2. Filter the data using the 'Hostname' dimension to select the blog(s) you are interested in.  For example, if you were only interested in views of GDS blog pages, you could filter down to 'Hostname' contains 'gds.blog.gov.uk'. Note that if you filtered to just 'Hostname' contains 'gds' you would get page views both of gds.blog.gov.uk pages and gdsengagement.blog.gov.uk pages
+3. Change the date range and sort the table however you like
+
+An example exploration showing GDS blog page views can be [accessed here](https://analytics.google.com/analytics/web/#/analysis/p436727455/edit/NM1gscgjRkygWLN-Es2gww).
+
+Remember to check the [data quality icons](https://support.google.com/analytics/answer/12856703?hl=en) when using reports or explorations in GA, and to keep an eye open for the impact of our high cardinality data in Looker Studio.
+

--- a/source/analysis/content-data/index.html.md.erb
+++ b/source/analysis/content-data/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use the Content Data app
-weight: 33
+weight: 34
 last_reviewed_on: 2024-05-16
 review_in: 6 months
 ---

--- a/source/analysis/ga-ua-data/index.html.md.erb
+++ b/source/analysis/ga-ua-data/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use the historic analytics (UA) data
-weight: 32
+weight: 33
 last_reviewed_on: 2024-06-28
 review_in: 6 months
 ---

--- a/source/analysis/use-search-console/index.html.md.erb
+++ b/source/analysis/use-search-console/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Use the GOV.UK Search Console data
-weight: 34
+weight: 35
 last_reviewed_on: 2024-06-08
 review_in: 6 months
 ---

--- a/source/data-sources/ga/blogs-ga4/index.html.md.erb
+++ b/source/data-sources/ga/blogs-ga4/index.html.md.erb
@@ -1,0 +1,52 @@
+---
+title: GOV.UK blogs GA4
+weight: 4
+last_reviewed_on: 2024-07-17
+review_in: 6 months
+---
+
+# GOV.UK blogs GA4
+Google Analytics 4 (GA4) is used to collect data on the usage of the GOV.UK blogs.
+
+This data can be accessed via the Google Analytics 4 user interface, the GA4 Looker Studio connection, and the Google Analytics Data API.
+
+
+Information on how to understand and use this data can be found in the [Analysis section of this site](/analysis/blogs-ga4/).
+
+## Content
+
+Data was first collected into this property on 07/06/22.
+
+## Access
+Blog editors should be able to grant users access to the blogs GA4 property. 
+
+If you have any issues, please contact the [GOV.UK GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
+
+### Location
+There are three GA4 GOV.UK properties. These correspond to the integration, staging, and production or live GOV.UK websites.
+
+## GA4 settings
+### Property set-up
+At set-up, we chose the following reporting options:
+
+- Reporting timezone of United Kingdom - (GMT+01:00) United Kingdom Time
+- Currency is British Pound (£)
+- Industry category of Law and Government 
+- When asked about our business objectives (which determines which standard reports GA4 will provide in the property), we chose 'Get baseline reports' 
+
+### Data collection
+
+Google Signals data collection and Ads personalisation is disabled for GDS GA4 properties within the interface.
+
+Granular location and device data collection is enabled to allow reporting on the city-level location and devices used by our users.
+
+### Data processing and modification
+
+At present, we have not created any custom events or designated any events as conversions within GA4.
+
+We are also not using GA4's inbuilt data redaction feature on GOV.UK.
+If you spot any PII or other data that should not be present in any GDS GA4 datasets, please raise a Zendesk ticket or contact the Analytics team.
+
+### Retention
+
+A data retention period for this data is set in the GA4 user interface. For the integration, staging, and production GOV.UK sites, this is set to 38 months.

--- a/source/data-sources/ga/ga-settings/index.html.md.erb
+++ b/source/data-sources/ga/ga-settings/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GA Settings Database
-weight: 8
+weight: 9
 last_reviewed_on: 2024-05-23
 review_in: 6 months
 ---

--- a/source/data-sources/ga/historic-ua/index.html.md.erb
+++ b/source/data-sources/ga/historic-ua/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Historic analytics (Universal Analytics) data
-weight: 4
+weight: 5
 last_reviewed_on: 2024-06-28
 review_in: 6 months
 ---

--- a/source/data-sources/ga/ua-flat/index.html.md.erb
+++ b/source/data-sources/ga/ua-flat/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GOV.UK Universal Analytics flattened tables
-weight: 6
+weight: 7
 last_reviewed_on: 2024-05-23
 review_in: 6 months
 ---

--- a/source/data-sources/ga/ua/index.html.md.erb
+++ b/source/data-sources/ga/ua/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GOV.UK Universal Analytics (BigQuery export)
-weight: 5
+weight: 6
 last_reviewed_on: 2024-06-28
 review_in: 6 months
 ---

--- a/source/data-sources/gcp-logs/index.html.md.erb
+++ b/source/data-sources/gcp-logs/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Google Cloud Platform logs
-weight: 7
+weight: 8
 last_reviewed_on: 2024-04-25
 review_in: 6 months
 ---


### PR DESCRIPTION
Adding pages with basic information on the Blogs GA4, to answer some frequently asked questions. Trello card: https://trello.com/c/EzyCvGUi/283-update-data-docs-with-basic-info-on-access-and-use-of-blogs-ga4-data