### PR TITLE
Adding notes to GA4 data source page

### DIFF
--- a/source/data-sources/ga/ga4/index.html.md.erb
+++ b/source/data-sources/ga/ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4
 weight: 1
-last_reviewed_on: 2024-06-04
+last_reviewed_on: 2024-07-26
 review_in: 6 months
 ---
 
@@ -41,6 +41,8 @@ At set-up, we chose the following reporting options:
 - Business size - Very Large
 - When asked about our business objectives (which determines which standard reports GA4 will provide in the property), we chose 'Get baseline reports' 
 
+No [subproperties](https://support.google.com/analytics/answer/11525732) are set up for the GOV.UK GA4 properties.
+Instead, we are using BigQuery and Looker Studio to clean, filter, and control access to the data.
 
 ### Data collection
 
@@ -57,14 +59,16 @@ Granular location and device data collection is enabled to allow reporting on th
 ### Data processing and modification
 
 At present, we have not created any custom events or designated any events as conversions within GA4.
+We have tested the custom event data import feature to ensure that it would meet our needs to join additional metadata to the events we collect, and may use this in future. 
+If you are interested in adding custom events, conversions, or data imports to the GOV.UK GA4 data, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
 
-No [subproperties](https://support.google.com/analytics/answer/11525732) are set up for the GOV.UK GA4 properties.
-Instead, we are using BigQuery and Looker Studio to clean, filter, and control access to the data.
+[Expanded datasets](/analysis/govuk-ga4/use-ga4/ga4-expanded-datasets/) are being used to reduce the impact of cardinality on various key reports.
+You can use the [steps in this guidance](/analysis/govuk-ga4/use-ga4/ga4-expanded-datasets/) to view the expanded datasets we have set up and to request new expanded datasets.
 
 We are also not using GA4's inbuilt data redaction feature on GOV.UK.
 Instead, we are applying redaction to strip out potential Personally Identifable Information (PII) from values before they are pushed to the dataLayer (see our [documentation on this in GitHub](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/pii-remover.md)).
 Additional PII redaction is also applied in Google Tag Manager as a fail-safe.
-If you spot any PII or other data that should not be present in the GA4 datasets, please raise a Zendesk ticket or contact the Analytics team.
+If you spot any PII or other data that should not be present in the GA4 datasets, please raise a Zendesk ticket or contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
 
 ### Retention
 


### PR DESCRIPTION
Adding notes to GA4 data source page on custom event data import (linked to https://trello.com/c/iPLbxe2e/301-test-custom-event-data-import) and expanded datasets (linking to pre-existing guidance), plus a couple other minor bits of tidy up.