### PR TITLE
Updating out of date onboarding information

### DIFF
--- a/source/get-started/onboard-data-labs/index.html.md.erb
+++ b/source/get-started/onboard-data-labs/index.html.md.erb
@@ -1,13 +1,13 @@
 ---
-title: New starter onboarding - Data Products
+title: New starter onboarding - Data Services
 weight: 21
-last_reviewed_on: 2021-09-09
+last_reviewed_on: 2024-08-12
 review_in: 6 months
 ---
 
-# New starter onboarding - Data Products
+# New starter onboarding - Data Services
 
-Use this new starter onboarding guidance if you are a new member of the Data Products team.
+Use this new starter onboarding guidance if you are a new member of the Data Services team.
 
 You should use the following guidance when:
 
@@ -28,6 +28,5 @@ The new starter guidance also has [reference information](/get-started/reference
 - the GDS Way
 - GOV.UK Confluence
 - the Aqua book for maintaining analytical quality assurance (AQA)
-- pre-existing code to reuse
 - learning and development resources
 - example code

--- a/source/get-started/onboard-data-labs/set-up-local-machine/index.html.md.erb
+++ b/source/get-started/onboard-data-labs/set-up-local-machine/index.html.md.erb
@@ -1,43 +1,38 @@
 ---
 title: Set up your local machine
 weight: 30
-last_reviewed_on: 2021-09-09
+last_reviewed_on: 2024-08-12
 review_in: 6 months
 ---
 
 # Set up your local machine
 
-When you join the GOV.UK Data Products team, you must set up your local machine and join Google groups.
+When you join the GOV.UK Data Services team, you must ensure your local machine is set up correctly, and that you are in the right Google groups.
 
 ## Set up your local machine
 
+If you are a new member of technical staff (a developer, data scientist, or an analyst), you will need to set up your machine.
+If you are not expecting to do any work requiring coding, or access to AWS or GitHub, you can ignore this step.
+
 To set up your local machine, follow the [Get started on GOV.UK documentation](https://docs.publishing.service.gov.uk/manual/get-started.html).
 
-Once you have set up your local machine by following this documentation, you should have access to GitHub and AWS. If you are a data scientist, ask in the [GOV.UK Data Products slack channel](https://gds.slack.com/archives/CHR4UQKU4) for someone to add you to the:
-
-- `ukgovdatascience` organisation in GitHub
-- `govuk-integration-datascience` AWS role, also known as the `govuk-datascienceusers` AWS IAM role
+Once you have set up your local machine by following this documentation, you should have access to GitHub and AWS.
 
 ## Join Google Groups
 
 You should join various Google Groups to be able to access group emails and calendars. To join any of the Google Groups linked below, select the link, and then select __Ask to join group__.
+If a Group is not linked below, ask your delivery manager to help you gain access.
 
-All GOV.UK Data Products members:
+All GOV.UK Data Services members:
 
 - [govuk-members](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-members)
-- [GOV.UK Data Products](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gov.uk-data-labs)
+- the GOV.UK Data Services team group
+
+Performance analysts:
+
+- [GDS Performance and Data Analysts](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/performance-analysts)
 
 Data scientists:
 
 - [GOV.UK Data Science](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/govuk-data-science)
 - [Data Science at GDS](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/gds-data-science)
-- [gds-data-science-team](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/BUOD)
-
-All analysts:
-
-- [Cabinet Office Analysts](https://groups.google.com/a/cabinetoffice.gov.uk/g/analysts)
-
-Other useful Google Groups:
-
-- [cyber monthly report](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/cybersecurity-monthly-report) - a monthly newsletter from the GDS Cyber Security team, including GitHub repositories with vulnerabilities
-- [CO Coffee & Coding](https://groups.google.com/a/cabinetoffice.gov.uk/g/coffee-and-coding-group) - the Cabinet Office Coffee and Coding group

--- a/source/get-started/onboard-data-labs/start-new-project/index.html.md.erb
+++ b/source/get-started/onboard-data-labs/start-new-project/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Start a new data science project
 weight: 40
-last_reviewed_on: 2021-09-09
+last_reviewed_on: 2024-08-12
 review_in: 6 months
 ---
 
@@ -10,7 +10,7 @@ review_in: 6 months
 When starting a new data science project, you should:
 
 - store your project in GitHub
-- set up your project using `govcookiecutter`
+- (optional) set up your project using `govcookiecutter`
 - organise your workload using Trello
 
 ## Store your projects in GitHub
@@ -22,14 +22,11 @@ See the [GOV.UK developer documentation on setting up your GitHub account](https
 You should follow best practice when storing projects in GitHub:
 
 - store GOV.UK projects in [`alphagov` organisation](https://github.com/alphagov) repos
-- store non-GOV.UK projects in [`ukgovdatascience` organisation](https://github.com/ukgovdatascience) repos
 - do not store repos under your GitHub username
 - set your repo to public where possible as the GOV.UK Data Products team likes to code in the open
 - when naming your repo, use hyphens instead of underscores to separate words.
 - to make sure colleagues have access to repo if the repo owner leaves, grant the following GitHub teams access to your `alphagov` repositories:
-  - admin access: `gov-uk-data`
-- for `ukgovdatascience` repos, grant the following GitHub teams access:
-  - write access: `gdsdatascience`
+- admin access: `gov-uk-data`
 
 By default, GitHub organisation owners have admin access to all repos. If you cannot access a repo, speak to the owner for access.
 
@@ -49,7 +46,7 @@ You must add branch protection rules to the `main` branch of your repo to preven
 
 ## Set up your project using `govcookiecutter`
 
-You should use `govcookiecutter` to set up your data science project.
+You can use `govcookiecutter` to set up your data science projects.
 
 [`govcookiecutter`](https://github.com/ukgovdatascience/govcookiecutter) is a template for data science projects in HM Government and the wider public sector.
 
@@ -70,16 +67,10 @@ For more information, see the:
 
 ## Organise your workload using Trello
 
-GOV.UK Data Products adopts [Agile ways of working](https://agilemanifesto.org/). We use Trello to maintain a team-wide [Kanban-style way of working](https://en.wikipedia.org/wiki/Kanban_(development)), although specific projects may adopt other methodologies such as [Scrum](https://scrumguides.org/index.html).
+GOV.UK Data Services adopts [Agile ways of working](https://agilemanifesto.org/).
+We use Trello to maintain a team-wide [Kanban-style way of working](https://en.wikipedia.org/wiki/Kanban_(development)), although specific projects may adopt other methodologies such as [Scrum](https://scrumguides.org/index.html).
 
-To make sure all projects are visible to the team, you should write and update cards on Trello. GOV.UK Data Products has two Trello boards:
-
-- the [Data Products doing board](https://trello.com/b/FMptFIIw/data-labs-doing-board), a Trello board for all tasks in the current sprint
-- the [Data Products planning board](https://trello.com/b/s6TGpjeA/data-labs-planning-board), a Trello board for all planned tasks for future sprints
-
-For new epics, create an epic using the __Epic template__ card and summarise the epic.
-
-For new and existing projects, create stories using the __Story template__ card.
+To make sure all projects are visible to the team, you should write and update cards on Trello.
 
 Stories should cover a specific task that has a valid acceptance criteria. Acceptance criteria are your “definition of done”. You should make the minimum developments to meet this criteria.
 


### PR DESCRIPTION
Removing out of date onboarding information and switching references to the old Data Products team to Data Services (linked to work on https://trello.com/c/V1gK81ay/62-write-update-ga-guidance-for-pa-new-starters-in-gds)