### PR TITLE
Adding notes from confluence pages and on conversions/key events

### DIFF
--- a/source/analysis/spider-diagram/index.html.md.erb
+++ b/source/analysis/spider-diagram/index.html.md.erb
@@ -1,9 +1,8 @@
 ---
 title: Use the spider diagram tool
 weight: 39.3
-last_reviewed_on: 2022-02-23
+last_reviewed_on: 2024-08-19
 review_in: 6 months
-hide_in_navigation: true
 ---
 
 # Use the spider diagram tool
@@ -19,39 +18,14 @@ This data is over a date range and is broken down by:
 - internal/external links
 - individual entry/exit pages paired with the count and proportion of page views
 
+This tool was developed within Data Services for use by analysts within GDS, and can be found in the 'Path tools' folder in the 'Performance and Data Analysts Community' shared Google Drive.
+
 To use the spider diagram tool, you must do the following:
 
-1. Download the spider diagram tool notebook.
+1. Make a copy of the spider diagram tool notebook.
 1. Open the tool notebook in Google Colab.
 1. Run the tool notebook.
-1. Save a local copy of the data.
-
-## Download the spider diagram tool notebook
-
-You need to download the notebook from GitHub.
-
-1. Go to the [`govuk-user-journey-analysis-tools` GitHub repo](https://github.com/alphagov/govuk-user-journey-analysis-tools).
-1. Select the __Code__ button, and then select __Download Zip__.
-1. Unzip the __govuk-user-journey-analysis-tools__ folder.
-1. Go to the __notebooks__ folder.
-1. Save the __spider-diagram-tool__ Jupyter notebook to your Google Drive account.
-
-## Open the tool notebook in Google Colab
-
-1. Go to [Google Colab](https://colab.research.google.com/). You'll see a pop-up window which will prompt you to open a notebook.
-1. Select the __Google Drive__ tab.
-1. Open the __spider-diagram-tool__ notebook.
-
-### Associate Jupyter notebooks with Google Colab
-
-To open a Juypter notebook in Google Colab from Google Drive for the first time, you must associate Juypter notebooks with Google Colab. You’ll only have to do this once.
-
-1. Right-click anywhere in Google Drive and select __More__.
-1. Select __Connect more apps__.
-1. Select __Google Colaboratory__.
-1. Accept any required permissions.
-
-Once you have associated Juypter notebooks with Google Colab, you can open a Juypter notebook in Google Colab from Google Drive.
+1. View the outputs and save a local copy of the data.
 
 ## Run the tool notebook
 
@@ -63,13 +37,12 @@ To run the notebook, you must do the following.
 1. Run the __Execute queries__ cell.
 1. Create and download the visualisation.
 
-### Authenticate your access
 
-1. Hover your cursor over the cell that starts with the code `from datetime import datetime` to show the run icon. To start the authentication process, select the run icon, which is in the top left corner of the cell.
-1. Select the authentication link in the text box and then select your Google account.
-1. Follow the on-screen prompts, selecting __Allow__ when prompted, and copy the __Sign in code__ when this code appears.
-1. Go back to the text box in the notebook and paste the sign-in code into the __Enter verification code__ field.
-1. Select __Enter__ to complete authentication.
+### Authenticating your access
+
+1. Run the cells in order. When running cell 1 - `auth.authenticate_user()` - you will see a pop-up asking you to authenticate
+2. Follow the on screen prompts, selecting your account and __Allow__ when prompted
+3. The cell will show as successfully run - with a small green tick - when you have successfully authenticated
 
 If you receive a warning message saying "The notebook was not authored by Google", select __Run Anyway__.
 
@@ -86,8 +59,8 @@ You must complete and run the cells in the __Input Variables__ section.
   - device categories - you must select at least one device type from __Desktop__, __Mobile__ or __Tablet__, otherwise the code will not run and will raise a `ValueError`
 
   You do not need to change the following fields:
-  - `project_id` - this is always `govuk-bigquery-analytics`
-  - `ga_dataset` - this is always `87773428`
+  - `project_id` - this is always `gds-bq-reporting`
+  - `ga_dataset` - this is always `analytics_330577055` - the [GOV.UK GA4 Production dataset](/data-sources/ga/ga4-bq/)
 
 1. Select __Runtime__ and then __Run after__ to run all the cells in the __Input Variables__ section.
 

--- a/source/data-sources/ga/ga4/index.html.md.erb
+++ b/source/data-sources/ga/ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4
 weight: 1
-last_reviewed_on: 2024-07-26
+last_reviewed_on: 2024-08-19
 review_in: 6 months
 ---
 
@@ -58,9 +58,14 @@ Granular location and device data collection is enabled to allow reporting on th
 
 ### Data processing and modification
 
-At present, we have not created any custom events or designated any events as conversions within GA4.
+At present, we have not created any custom events or designated any events as key events (formerly known as conversions) within GA4.
+We have so far decided to not implement any key events as:
+
+- they might require the creation of an additional event, to be designated as the key event, and this would increase our data collection and storage costs as well as issues with high cardinality and sampling when using our data
+- they would have an impact on our engagement rates
+
 We have tested the custom event data import feature to ensure that it would meet our needs to join additional metadata to the events we collect, and may use this in future. 
-If you are interested in adding custom events, conversions, or data imports to the GOV.UK GA4 data, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
+If you are interested in adding custom events, key events, or data imports to the GOV.UK GA4 data, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
 
 [Expanded datasets](/analysis/govuk-ga4/use-ga4/ga4-expanded-datasets/) are being used to reduce the impact of cardinality on various key reports.
 You can use the [steps in this guidance](/analysis/govuk-ga4/use-ga4/ga4-expanded-datasets/) to view the expanded datasets we have set up and to request new expanded datasets.

--- a/source/data-sources/ga/index.html.md.erb
+++ b/source/data-sources/ga/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Google Analytics
 weight: 1
-last_reviewed_on: 2024-08-16
+last_reviewed_on: 2024-08-19
 review_in: 6 months
 ---
 
@@ -28,6 +28,9 @@ The majority of access is granted at property level.
 
 All GDS GA4 properties should be created at this tier.
 This is to ensure data collected is covered by our 360 contract terms.
+
+Google Analytics 360 also has a number of advantages over the free tier, providing higher limits on data collection, reporting, retention, and export to BigQuery.
+More information on the differences between free Google Analytics and Google Analytics 360 can be found on Google's [support pages](https://support.google.com/analytics/answer/11202874).
 
 If you have created a new GDS Google Analytics property and need to upgrade it to 360, please contact the Analytics team.
 

--- a/source/get-started/get-permissions/aws-cli-assume-role/index.html.md.erb
+++ b/source/get-started/get-permissions/aws-cli-assume-role/index.html.md.erb
@@ -3,6 +3,7 @@ title: Set up AWS CLI to assume roles with MFA and interact with GDS AWS
 weight: X
 last_reviewed_on: 2022-09-07
 review_in: 12 months
+hide_in_navigation: true
 ---
 
 # Set up AWS CLI to assume roles with MFA and interact with GDS AWS

--- a/source/get-started/get-permissions/aws-python-boto3-assume-role/index.html.md.erb
+++ b/source/get-started/get-permissions/aws-python-boto3-assume-role/index.html.md.erb
@@ -3,6 +3,7 @@ title: Set up Python boto3 to assume AWS roles with MFA and interact with GDS AW
 weight: X
 last_reviewed_on: 2022-09-07
 review_in: 12 months
+hide_in_navigation: true
 ---
 
 # Set up AWS Python SDK (boto3) to assume roles with MFA and interact with GDS AWS

--- a/source/get-started/get-permissions/index.html.md.erb
+++ b/source/get-started/get-permissions/index.html.md.erb
@@ -3,6 +3,7 @@ title: Assume a specific role in AWS
 weight: 23
 last_reviewed_on: 2022-07-22
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Assume a specific role in AWS

--- a/source/get-started/onboard-performance-analysis/index.html.md.erb
+++ b/source/get-started/onboard-performance-analysis/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: New starter onboarding - Performance Analysis
 weight: 23
-last_reviewed_on: 2024-08-14
+last_reviewed_on: 2024-08-19
 review_in: 6 months
 ---
 
@@ -31,7 +31,17 @@ Key tools that analysts will use are:
 
 Make sure you have access to the right GA4 data sources for your role. Ask your line manager or other performance analysts if you are unsure about whether you have the right access.
 
-Other tools some analysts in the community use and find useful include:
+We also have some Tableau licences. Speak to others in the analyst community if you would like to use Tableau.
+
+The following may be useful for analysis of users' journeys:
+
+- DISCO, and the DISCO prep tool 
+- the [forward and reverse path tools](/analysis/forward-path/)
+- the [spider diagram tool](/analysis/spider-diagram/)
+- the [pogosticking tool](/analysis/pogostick/)
+- the inferring user journeys tool
+
+Other external tools some analysts in the community use and find useful include:
 
 - [Omnibug](https://chromewebstore.google.com/detail/omnibug/bknpehncffejahipecakbfkomebjmokl)
 


### PR DESCRIPTION
Adding a few notes inspired by working through the analysis community confluence (this trello card: https://trello.com/c/wN4a2qOx/312-clean-up-analytics-guidance-in-analysis-community-confluence) and linked to our recent accidental experiment with conversions/key events (https://trello.com/c/fXzn8PDi/166-discuss-and-test-ga4-conversions-key-events)

Also decided to hide a couple of AWS pages from the navigation as I wasn't sure how useful or up-to-date they were, and wanted to reduce clutter