### PR TITLE
More page updates from recent analytics team work

### DIFF
--- a/source/analysis/best-bets/index.html.md.erb
+++ b/source/analysis/best-bets/index.html.md.erb
@@ -1,9 +1,8 @@
 ---
 title: Change search results on GOV.UK (best bets)
 weight: 36
-last_reviewed_on: 2021-09-09
+last_reviewed_on: 2024-08-20
 review_in: 6 months
-hide_in_navigation: true
 ---
 
 # Change search results on GOV.UK (best bets)

--- a/source/analysis/use-search-console/index.html.md.erb
+++ b/source/analysis/use-search-console/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Use the GOV.UK Search Console data
 weight: 35
-last_reviewed_on: 2024-06-08
+last_reviewed_on: 2024-08-21
 review_in: 6 months
 ---
 
@@ -25,6 +25,13 @@ GDS users will be able to run queries in a range of projects in BigQuery, such a
 Users from other organisations will need to query the data from a Google Cloud Platform project with billing owned by their organisation.
 
 If you are new to BigQuery, you may find it helpful to review Google’s [documentation explaining the BigQuery user interface](https://cloud.google.com/bigquery/docs/bigquery-web-ui#open-ui).
+
+### Tables and fields
+
+Information on the two Search Console tables can be found on the [data source page](/data-sources/gsc/).
+
+Queries can be returned with `null` values if they are rare. In these cases, the 'is_anonymized_query' field should be marked with this bool.
+The query field will be `null` when it is true to protect the privacy of users making the query. More information on this can be found in [Google's documentation on Search Console performance data filtering and limits](https://developers.google.com/search/blog/2022/10/performance-data-deep-dive#privacy-filtering).
 
 ### Example query
 

--- a/source/data-sources/gsc/index.html.md.erb
+++ b/source/data-sources/gsc/index.html.md.erb
@@ -24,10 +24,11 @@ More information can be found in our [GA access policy](/processes/ga-access/#wh
 
 ### Location
 
-GSC data for the www.gov.uk site is located in BigQuery in the `ga4-analytics-352613.searchconsole_wwwgovuk` dataset.
-
-This is within the [GA4 analytics project](/tools/google-cloud-platform/gcp-projects/#ga4-analytics).
-There are 2 partitioned tables: `searchdata_site_impression` and `searchdata_url_impression`.
+GSC data for the www.gov.uk site is located in BigQuery in the `ga4-analytics-352613.searchconsole_wwwgovuk` dataset, within the [GA4 analytics project](/tools/google-cloud-platform/gcp-projects/#ga4-analytics).
+There are two partitioned tables: `searchdata_site_impression` and `searchdata_url_impression`. 
+The `searchdata_site_impression` table contains performance data for our GOV.UK property aggregated at the site/property level.
+The `searchdata_url_impression` table contains performance data for aggregated by URL.
+More information on Search Console data can be found in [Google's documentation](https://support.google.com/webmasters/answer/12917991?hl=en).
 
 For more information on the Google Cloud Platform projects, see our [GCP Project Documentation](/tools/google-cloud-platform/gcp-projects).
 

--- a/source/get-started/index.html.md.erb
+++ b/source/get-started/index.html.md.erb
@@ -1,10 +1,10 @@
 ---
-title: New starter onboarding
+title: New starter onboarding and reference information
 weight: 20
-last_reviewed_on: 2024-08-09
+last_reviewed_on: 2024-08-20
 review_in: 6 months
 ---
 
-# New starter onboarding
+# New starter onboarding and reference information
 
 The information in this section may be of use if you are a data professional who has recently joined the Government Digital Service.

--- a/source/get-started/onboard-performance-analysis/index.html.md.erb
+++ b/source/get-started/onboard-performance-analysis/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: New starter onboarding - Performance Analysis
 weight: 23
-last_reviewed_on: 2024-08-19
+last_reviewed_on: 2024-08-20
 review_in: 6 months
 ---
 
@@ -16,11 +16,28 @@ Remember that it is [it's ok to say what's ok](https://gds.blog.gov.uk/2016/05/2
 
 When you join GDS as a performance analyst, please make sure to:
 
-- join the #analysis Slack channel 
+- get access to and go through the []'Welcome to being a Performance Analyst at GDS' trello board](https://trello.com/b/dp3ZPezz/welcome-to-being-a-performance-analyst-at-gds-main-version)
+
+### Get access to useful groups and communities 
+
+- join the #analysis and #analysts GDS Slack channels
 - get access to the Performance Analysts calendar (ask a Lead Performance Analyst to invite you), and come along to the weekly community hours
+- get access to the Performance Analysts Google group, plus any Google groups associated with your team and directorate
+- get access to the [cross-government Basecamp communities](https://3.basecamp.com/4322319/projects/14530097)
+
+### Learn about how we work 
+
 - learn about what it is like to work as a performance analyst embedded in a multidisciplinary team - [read this document](https://docs.google.com/document/d/1C-G6DRgyPggrX6w79HrXKeIYA7M7Kyc15g9C9KHZSi0/) and talk to your line manager 
 - learn about [performance frameworks](https://docs.google.com/presentation/d/1G-25i8blEtwUSUsV18pL61AoFih7ZdMWMBsBZTqeDgw/)
 - get familiar with our weeknotes, and contribute your updates at the end of every week
+- familiarise yourself with the [service manual](https://www.gov.uk/service-manual), [design principles](https://www.gov.uk/guidance/government-design-principles), and [style guide](https://www.gov.uk/government/collections/content-and-publishing-guidance-for-government)
+- read up on what the rest of [GDS is up to](https://www.gov.uk/government/organisations/government-digital-service) the state of [data in government](https://dataingovernment.blog.gov.uk/)
+
+### Sort the practical things
+
+- get your line manager to apply for your building pass
+- make sure you have access to SOP and the intranet, and understand the core hardware and software we use
+- familiarise yourself with Google apps and our Google Drive
 
 ## Tools for analysts
 
@@ -44,6 +61,11 @@ The following may be useful for analysis of users' journeys:
 Other external tools some analysts in the community use and find useful include:
 
 - [Omnibug](https://chromewebstore.google.com/detail/omnibug/bknpehncffejahipecakbfkomebjmokl)
+- [Google Trends](https://trends.google.com/trends/)
+
+External reporting that may also be of interest include:
+
+- [Citizens Advice's 'advice trends'](https://www.citizensadvice.org.uk/about-us/information/advice-trends-on-tableau/)
 
 ## Useful resources for analysts
 
@@ -56,7 +78,7 @@ There is a wealth of information on this site which will be good to know for ana
 
 Other resources that might be useful include:
 
-- [the GDS style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style)
+- the [service manual](https://www.gov.uk/service-manual), [design principles](https://www.gov.uk/guidance/government-design-principles), and [style guide](https://www.gov.uk/government/collections/content-and-publishing-guidance-for-government)
 - this [list of the applications supporting GOV.UK, and which teams own them](https://docs.publishing.service.gov.uk/apps.html#applications-on-gov-uk)
 - this [GOV.UK API 'cheat sheet'](https://gist.github.com/sihugh/028fdcd06c5152964abaf09f6857db1d)
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,25 +1,20 @@
 ---
 title: Data Services Technical Documentation
 weight: 10
-last_reviewed_on: 2024-02-20
+last_reviewed_on: 2024-08-21
 review_in: 6 months
 ---
 
 # Data Services technical documentation
 
-Data Services is a group of teams in the GOV.UK directorate, including:
-
-- Data insights
-- Analytics
-
-This site is a central store of technical documentation for the data  community, and should be the default place to record information and decisions. 
+This site is a central store of technical documentation for the data community working on GOV.UK, and should be the default place to record information and decisions. 
 Any private or sensitive information should be linked to from here rather than written here directly.
 
 Use this documentation if you need to find out information on:
 
-- getting started as a new member of the community
-- analysis best practice and methodology
-- available data sources and tools
+- [getting started as a new member of the community](/get-started/)
+- [analysis best practice and methodology](/analysis/)
+- available [data sources](/data-sources/) and [tools](/tools/)
 
 Contact one of the Data Services teams if you have any questions or feedback.
 

--- a/source/processes/ga-access/spocs/index.html.md.erb
+++ b/source/processes/ga-access/spocs/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Analytics SPOCs
 weight: 2
-last_reviewed_on: 2024-02-20
+last_reviewed_on: 2024-08-21
 review_in: 6 months
 ---
 
@@ -14,12 +14,17 @@ This includes adding new starters and removing those who no longer need access (
 Every SPOC will be provided with reporting to enable them to [monitor their organisation's users' usage](/processes/ga-access/#monitoring-and-reporting).
 
 ## How to become a SPOC
-The nominated SPOC will need access to Signon. Access to Signon can be arranged by your organisation's content SPOC.
-
 To request a change of SPOC, raise a request via the [Analytics Support Form](https://support.publishing.service.gov.uk/analytics_request/new) stating who the new SPOC will be.
 
-## Resources
-[SPOC user report](https://lookerstudio.google.com/reporting/3efb1388-9c6f-4265-beea-caea6b5a89fb/page/3GYgD)
+The nominated SPOC will need access to Signon. Access to Signon can be arranged by your organisation's content SPOC.
 
-[Analytics Support Form](https://support.publishing.service.gov.uk/analytics_request/new)
+## Resources for SPOCs
+
+For any user admin requests:
+
+- [Analytics Support Form](https://support.publishing.service.gov.uk/analytics_request/new) in Signon
+
+To monitor your organisations' users:
+
+- [SPOC user report](https://lookerstudio.google.com/reporting/3efb1388-9c6f-4265-beea-caea6b5a89fb/page/3GYgD)
 

--- a/source/processes/ga-deletion/index.html.md.erb
+++ b/source/processes/ga-deletion/index.html.md.erb
@@ -1,0 +1,56 @@
+---
+title: GA4 data deletions
+weight: 3
+last_reviewed_on: 2024-08-21
+review_in: 6 months
+---
+
+# GA4 data deletions
+<span style="color:red">This page is a work in progress.</span>
+
+This page details the policy and process we follow when deleting production GA4 data.
+
+## When do we delete GA4 data?
+
+We will delete GA4 data when it meets any of the following criteria: 
+
+1. When we believe the data was collected without adequate user consent 
+2. When data collected contains personally identifiable information and/or we are advised by our data protection and privacy specialists that it should be deleted
+3. When data collected is ‘wrong’, inaccurate or otherwise deemed to be unhelpful to data users, and it is:
+    a. A significant enough number of events to be worth deleting or partially deleting (1 million events a day, or 10 million events in total), and
+    b. Possible to delete in the GA4 interface and in BigQuery without deleting other accurate and useful data 
+
+
+With regards criterion 3a, we believe the number of events is a useful indicator of the impact the presence of this incorrect data is likely to have on data users (more events are more noticeable and more likely to appear in reporting, so probably more worth deleting) and of the costs we will be paying to store this data in BigQuery.
+We are currently using 1 million events a day, or 10 million events in total, as useful rules of thumb for what might count as a significant number of events.
+This is only to be used as a guide or supporting piece of information when considering data deletions however, and is not a strict threshold.
+
+In the case of criterion 3b, we acknowledge the limitations of the GA4 data deletion feature, which means that it is not always possible to delete only a specific subset of our GA4 data.
+Depending on the ‘wrong’ nature of the data, it may be preferable to keep it if the alternative involves also deleting a large swathe of accurate and useful data.
+We also note that many products and other datasets rely on our GA4 BigQuery data, so in some cases it may be that the deletion of data in BigQuery is not worth it if it will not be hugely impactful (if it is data that is not heavily used) or, at the opposite end of the spectrum, if it will have a disruptive impact on other tools. 
+
+If the unwanted data collected is merely ‘wrong’ (criteria 3), we would likely not delete data from our raw GOV.UK GA4 dataset in BigQuery, only from our flattened and other processed datasets.
+This is because the risks associated with deleting raw data are not worth the benefits of removing incorrect data.
+
+## GA4 data deletion process
+
+1. Unwanted data is spotted and analysts/Analytics team are notified
+2. A fix is put in place to stop the unwanted data from being collected, if this hasn’t already been done
+3. Analysts figure out which datasets are impacted by the unwanted data collection, and determine using the criteria above whether it is possible and desirable to delete the unwanted data
+4. Relevant owners and/or Leads are informed of the recommendation on data deletion and asked to approve/feedback
+5. Unwanted data is deleted from the GA4 Data API using the GA4 data deletion feature, if this is possible and desirable
+    a. Data deletion request is scheduled. Data scheduled to be deleted must be at least 12 days old so the team may need to wait a fortnight to action this
+    b. Data deletion is checked during the preview/grace period  
+    c. Successful data deletion is checked and confirmed after the deletion request shows as processed. A data deletion request can take anything from 7 to 63 days, so this may take some time
+6. Unwanted data is deleted from the relevant BigQuery datasets, if this is possible and desirable, using a soft deletion or quarantine process. Note that data will only be deleted from the raw GA4 dataset if absolutely necessary (if the data was collected without consent or has to be deleted for data protection or privacy reasons) 
+    a. The data being deleted is moved out of the original source dataset into a quarantine dataset, and then deleted from the source dataset
+    b. If the data deletion has been checked and confirmed to be successful then the quarantine dataset is also deleted
+7. A notice on the data deletion is shared with the analyst community/data users and/or added to the GA4 data annotations table 
+
+## Owners and staff members’ responsibilities
+
+For [GOV.UK GA4 Production data](/data-sources/ga/ga4/):
+
+- The Lead Performance Analyst in Data will own GA4 API data deletions and be responsible for signing off any data deletion requests
+- The Lead Data Engineer in Data will own GA4 BigQuery data deletions and be responsible for signing off any data deletions
+- Members of Data Services responsible for the upkeep and maintenance of GOV.UK GA4 will action data deletion requests on the GOV.UK GA4 data and communicate the impact to the wider analyst community

--- a/source/processes/ga-pii/index.html.md.erb
+++ b/source/processes/ga-pii/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GA4 PII process
-weight: 5
-last_reviewed_on: 2024-02-23
+weight: 4
+last_reviewed_on: 2024-08-21
 review_in: 6 months
 ---
 
@@ -19,6 +19,6 @@ The Analytics team will:
  - Confirm whether the data identified is Personally Identifable Information 
  - Ascertain how long and why this data has been collected
  - Report it to our Data Protection & Privacy Specialist
- - Delete the data, if appropriate
+ - [Delete the data]/processes/ga-deletion/), if appropriate
  - Write an [incident report](https://docs.publishing.service.gov.uk/manual/incident-reports.html), if appropriate 
 

--- a/source/processes/ga-tracking-changes/index.html.md.erb
+++ b/source/processes/ga-tracking-changes/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GOV.UK GA4 tracking change process
-weight: 4
+weight: 2
 last_reviewed_on: 2024-08-15
 review_in: 6 months
 ---

--- a/source/teams/analytics/index.html.md.erb
+++ b/source/teams/analytics/index.html.md.erb
@@ -1,8 +1,9 @@
 ---
 title: Analytics team 
 weight: 1
-last_reviewed_on: 2024-04-25
+last_reviewed_on: 2024-08-21
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Analytics team

--- a/source/teams/index.html.md.erb
+++ b/source/teams/index.html.md.erb
@@ -1,8 +1,9 @@
 ---
 title: Teams
 weight: 30
-last_reviewed_on: 2024-04-25
+last_reviewed_on: 2024-08-21
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # Teams


### PR DESCRIPTION
More page updates from recent analytics team work, including:

- updates related to my review of documentation in analyst confluence spaces (https://trello.com/c/wN4a2qOx/312-clean-up-analytics-guidance-in-analysis-community-confluence)
- the addition on a page on the GA4 data deletion policy and process (https://trello.com/c/FrNbeySM/317-write-up-and-agree-ga4-data-deletion-policy)
- a review of the page on SPOCs as that was showing as needing a review (it had not been updated in >6 months)
- removing and hiding some information on the Data teams as our teams are changing and I am not sure this is relevant/useful right now