### PR TITLE
New page for event modifications policy, and reorganising policy pages

### DIFF
--- a/source/data-sources/ga/ga4/data-quality/index.html.md.erb
+++ b/source/data-sources/ga/ga4/data-quality/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 data quality
 weight: 1
-last_reviewed_on: 2024-09-09
+last_reviewed_on: 2024-09-16
 review_in: 6 months
 ---
 
@@ -21,6 +21,9 @@ We are currently developing a spreadsheet and Looker Studio report which contain
 
 ## Known issues with the GOV.UK GA4 data
 
+Note: this is a list of some larger scale issues which impact our data collection. 
+Shorter term bugs and issues with our tracking can be found in the above spreadsheet and Looker Studio.
+
 ### Data quality variance and content over time 
 
 Data was first collected into this property on 23/09/22.
@@ -39,12 +42,24 @@ We know a chunk of our users do not accept analytics cookies so we do not collec
 Some users may also be using ad blockers which inhibit Google Analytics from functioning.
 
 ### Incorrect event tracking
-#### Duplicate tracking on some navigation and copy events
+#### Assumptions in navigation tracking
 
-Due to the way navigation events have been implemented (firing on all right clicks on links), users who right click and select to ‘Copy’ a link will trigger both navigation and copy events.
+In order to capture users clicking on links in ways other than the usual left or primary click, we set up navigation (link) tracking so that all clicks on links trigger a navigation event to fire.
+
+This may mean some false positives in the data, as some right (secondary) clicks or other clicks may not necessarily lead to the user navigating through the link in question.
+For example, a user might be right clicking on a link to copy it or inspect it.
+If data users would like to exclude these clicks from their dataset, they can do so using the 'method' custom dimension.
+
+This is also why some duplicate tracking may be occuring with the navigation and copy tracking, as users who right click and select to ‘Copy’ a link will trigger both navigation and copy events.
 
 
-### Incorrect meta information in custom dimensions  
+### Incorrect information in custom dimensions  
+#### Issues with link information on pages with mistyped URLs
+When there is an extra / in the URL, the 'Link domain' information is incorrect, coming through as the first part of the path instead of the domain.
+This can be seen on the live site, for example if you interact with links on the `https://www.gov.uk//guidance/cost-of-living-payment#low-income-benefits-and-tax-credits-cost-of-living-payment-eligibility` page.
+Strictly, this URL should not be valid, but it (and many other incorrect URLs) do work to load content on GOV.UK. 
+Use of URLs like this is rare and so this should not cause too much of a data quality issue.
+
 #### Issues with publication and update dates
 The `first_published_at`, `public_updated_at` and `updated_at` dates sent with page view events may be misleading.
 

--- a/source/data-sources/ga/ga4/data-quality/index.html.md.erb
+++ b/source/data-sources/ga/ga4/data-quality/index.html.md.erb
@@ -54,7 +54,14 @@ This is also why some duplicate tracking may be occuring with the navigation and
 
 
 ### Incorrect information in custom dimensions  
-#### Issues with link information on pages with mistyped URLs
+#### Issues with users accessing GOV.UK in different languages  
+
+We capture what language a page was written in in the `content_language` dimension. The user's browser language is captured in the `language` dimension.
+However, there are a number of other ways users can translate page content - for example, using browser add-ons. 
+If the browser is translating the page content after the `page_view` event is sent, then the `page_view` will be sent with details in the original language (in most cases, English), though subsequent link clicks might be translated.
+However, there are some links (related content, amongst others) that we have hard-coded into the English to make them easier to analyse.
+
+#### Issues with link domain information in navigation tracking on pages with mistyped URLs
 When there is an extra / in the URL, the 'Link domain' information is incorrect, coming through as the first part of the path instead of the domain.
 This can be seen on the live site, for example if you interact with links on the `https://www.gov.uk//guidance/cost-of-living-payment#low-income-benefits-and-tax-credits-cost-of-living-payment-eligibility` page.
 Strictly, this URL should not be valid, but it (and many other incorrect URLs) do work to load content on GOV.UK. 

--- a/source/data-sources/ga/ga4/index.html.md.erb
+++ b/source/data-sources/ga/ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4
 weight: 1
-last_reviewed_on: 2024-08-19
+last_reviewed_on: 2024-09-16
 review_in: 6 months
 ---
 
@@ -59,13 +59,8 @@ Granular location and device data collection is enabled to allow reporting on th
 ### Data processing and modification
 
 At present, we have not created any custom events or designated any events as key events (formerly known as conversions) within GA4.
-We have so far decided to not implement any key events as:
-
-- they might require the creation of an additional event, to be designated as the key event, and this would increase our data collection and storage costs as well as issues with high cardinality and sampling when using our data
-- they would have an impact on our engagement rates
-
-We have tested the custom event data import feature to ensure that it would meet our needs to join additional metadata to the events we collect, and may use this in future. 
-If you are interested in adding custom events, key events, or data imports to the GOV.UK GA4 data, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
+We have tested the custom event data import feature to ensure that it would meet our needs to join additional metadata to the events we collect, but have not yet implemented any custom data imports.
+More information on GOV.UK GA4 data modifications can be found in the [Policies and processes section](/processes/ga-modifications/). 
 
 [Expanded datasets](/analysis/govuk-ga4/use-ga4/ga4-expanded-datasets/) are being used to reduce the impact of cardinality on various key reports.
 You can use the [steps in this guidance](/analysis/govuk-ga4/use-ga4/ga4-expanded-datasets/) to view the expanded datasets we have set up and to request new expanded datasets.

--- a/source/processes/ga-deletion/index.html.md.erb
+++ b/source/processes/ga-deletion/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GA4 data deletions
-weight: 3
+weight: 4
 last_reviewed_on: 2024-08-21
 review_in: 6 months
 ---

--- a/source/processes/ga-historic/index.html.md.erb
+++ b/source/processes/ga-historic/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Historic GA (UA) data
-weight: 7
+weight: 9
 last_reviewed_on: 2024-06-28
 review_in: 6 months
 ---

--- a/source/processes/ga-modifications/index.html.md.erb
+++ b/source/processes/ga-modifications/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Modifying GOV.UK GA4 data
 weight: 3
-last_reviewed_on: 2024-09-13
+last_reviewed_on: 2024-09-16
 review_in: 6 months
 ---
 
@@ -13,11 +13,41 @@ It is possible to modify the [GOV.UK GA4 data](/data-sources/ga/ga4/) within the
 
 Key events are set up within the interface.
 
+At present, we have not created any custom events or designated any events as key events (formerly known as conversions) within GA4.
+We have so far decided to not implement any key events as:
+
+- they might require the creation of an additional event, to be designated as the key event, and this would increase our data collection and storage costs as well as issues with high cardinality and sampling when using our data
+- they would have an impact on our engagement rates
+
+If you are interested in designating any events as key events in the GOV.UK GA4 data, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
+
 ## GA4 event modifications
 
-Event modifications can be set up within the GA4 interface.
+Events collected can be modified (parameter values changed or new parameters added) in the GA4 interface.
+Google have published some details on event modifications in their [support information](https://support.google.com/analytics/answer/12844695).
 
-This feature will only be used when there is no sensible way for developers to implement the same change to event tracking.
+This feature will only be used when there is no sensible way for developers to implement the same change to event tracking in the dataLayer.
 
 All regex used in GA4 event modifications should be audited by developers to ensure it will not worsen page load times.
 This is because there is a risk that complicated regex used might be slowing down the user's experience, as it is the user's computer which is doing the calculation.
+
+If event modifications are to be used, the following process should be followed:
+
+1. Event modification requested
+2. Need for and value of requested changes evaluated by the Analytics team
+3. Schema for proposed changes drawn up by the Analytics team and those requesting the changes
+4. Regex and/or other changes required written up in implementation guidance by the Analytics team and those requesting the changes
+5. Regex/changes checked by developers
+6. Changes tested by analysts in a testing environment
+7. Changes deployed to the live property by the Analytics team
+8. Changes documented and advertised by the Analytics team 
+
+If you are interested in modifying any events in the GOV.UK GA4 data, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
+
+## Custom data imports
+
+We have tested the custom event data import feature to ensure that it would meet our needs to join additional metadata to the events we collect.
+This feature is not currently in use, but may be used in future. 
+
+If you are interested in adding data imports to the GOV.UK GA4 data, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
+

--- a/source/processes/ga-modifications/index.html.md.erb
+++ b/source/processes/ga-modifications/index.html.md.erb
@@ -1,0 +1,23 @@
+---
+title: Modifying GOV.UK GA4 data
+weight: 3
+last_reviewed_on: 2024-09-13
+review_in: 6 months
+---
+
+# Modifying GOV.UK GA4 data
+
+It is possible to modify the [GOV.UK GA4 data](/data-sources/ga/ga4/) within the GA4 interface.
+
+## Key events
+
+Key events are set up within the interface.
+
+## GA4 event modifications
+
+Event modifications can be set up within the GA4 interface.
+
+This feature will only be used when there is no sensible way for developers to implement the same change to event tracking.
+
+All regex used in GA4 event modifications should be audited by developers to ensure it will not worsen page load times.
+This is because there is a risk that complicated regex used might be slowing down the user's experience, as it is the user's computer which is doing the calculation.

--- a/source/processes/ga-pii/index.html.md.erb
+++ b/source/processes/ga-pii/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GA4 PII process
-weight: 4
+weight: 5
 last_reviewed_on: 2024-08-27
 review_in: 6 months
 ---

--- a/source/processes/ga4-backfill/index.html.md.erb
+++ b/source/processes/ga4-backfill/index.html.md.erb
@@ -1,11 +1,11 @@
 ---
 title: GA4 backfill processes
-weight: 9
+weight: 8
 last_reviewed_on: 2024-09-03
 review_in: 6 months
 ---
 
-# GA4 Backfill Processes
+# GA4 backfill processes
 
 Each morning we receive yesterday's [GOV.UK GA4](/data-sources/ga/ga4/) data in [BigQuery](/data-sources/ga/ga4-bq/). 
 

--- a/source/processes/ga4-resources/index.html.md.erb
+++ b/source/processes/ga4-resources/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: GA4 resources
-weight: 6
+weight: 10
 last_reviewed_on: 2024-02-13
 review_in: 6 months
 ---


### PR DESCRIPTION
New page for event modifications policy (linked to https://trello.com/c/OfnvhGJI/303-o3kr2-test-ga4-event-modifications), and reorganising policy pages, plus data quality notes linked to https://trello.com/c/SEDW0ZiD/741-fix-link-domain-when-there-is-an-extra-slash-in-url and https://trello.com/c/y3lJp4nj/834-placeholder-q-about-languages-and-in-browser-translation