### PR TITLE
Updating GOV.UK GA4 data quality notes

### DIFF
--- a/source/analysis/best-practice/index.html.md.erb
+++ b/source/analysis/best-practice/index.html.md.erb
@@ -1,13 +1,17 @@
 ---
 title: Data analysis best practice
 weight: 30.1
-last_reviewed_on: 2024-05-16
+last_reviewed_on: 2024-09-18
 review_in: 6 months
 ---
 
 # Data analysis best practice
 
 There are multiple sources of data analysis best practice information.
+
+## The Service Manual 
+
+The Service Manual contains a wealth of useful information on [how to approach measuring success](https://www.gov.uk/service-manual/measuring-success).
 
 ## The Aqua book
 

--- a/source/analysis/govuk-ga4/understand-ua-differences/index.html.md.erb
+++ b/source/analysis/govuk-ga4/understand-ua-differences/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Understand differences between UA and GA4
 weight: 4
-last_reviewed_on: 2024-05-30
+last_reviewed_on: 2024-09-18
 review_in: 6 months
 ---
 
@@ -140,3 +140,16 @@ It is good to remember that Analytics data is not, and has never been, exact.
 
 The UA and GA4 interfaces are very different and at present the GA4 interface does not enable us to do everything we were used to being able to do in UA.
 We are working to find ways around this or put in feature requests to ensure that the tool better meets our needs.
+
+## Other resources
+### From GDS
+
+- [Previous blog post: How we’re preparing for the migration to Google Analytics 4](https://insidegovuk.blog.gov.uk/2022/08/24/how-were-preparing-for-the-migration-to-google-analytics-4/)
+- [Previous blog post: How GOV.UK is upgrading to Google Analytics 4](https://insidegovuk.blog.gov.uk/2022/11/03/how-gov-uk-is-upgrading-to-google-analytics-4/)
+- [Previous blog post: Sharing data and lessons from our Google Analytics 4 upgrade](https://gds.blog.gov.uk/2023/03/27/sharing-data-and-lessons-from-our-google-analytics-4-upgrade/)
+
+### From Google
+
+- [Notes on the differences between metrics in UA and GA4](https://support.google.com/analytics/answer/11986666)
+- [Notes on common analytics questions in GA4](https://support.google.com/analytics/answer/12964614)
+- [GA4 Reporting Playbook](https://services.google.com/fh/files/newsletters/google_analytics_4_reporting_playbook.pdf)

--- a/source/data-sources/ga/ga4/data-quality/index.html.md.erb
+++ b/source/data-sources/ga/ga4/data-quality/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 data quality
 weight: 1
-last_reviewed_on: 2024-09-16
+last_reviewed_on: 2024-09-18
 review_in: 6 months
 ---
 
@@ -53,18 +53,30 @@ If data users would like to exclude these clicks from their dataset, they can do
 This is also why some duplicate tracking may be occuring with the navigation and copy tracking, as users who right click and select to ‘Copy’ a link will trigger both navigation and copy events.
 
 
-### Incorrect information in custom dimensions  
+### Incorrect information in dimensions  
+#### Inconsistencies in 'outbound' values in attachment events
+
+On pages with attachment links, clicks on different links to download files come through with the `outbound` dimensions equalling 'true' as would be expected (as these files are hosted on https://assets.publishing.service.gov.uk).
+However, clicks on the preview link (to 'View online') come through with the `outbound` value of 'false' even through the preview is also hosted on https://assets.publishing.service.gov.uk.
+
+This is because in the source HTML the second link only has the page path, and is being redirected to the assets domain.
+
+
 #### Issues with users accessing GOV.UK in different languages  
 
-We capture what language a page was written in in the `content_language` dimension. The user's browser language is captured in the `language` dimension.
-However, there are a number of other ways users can translate page content - for example, using browser add-ons. 
-If the browser is translating the page content after the `page_view` event is sent, then the `page_view` will be sent with details in the original language (in most cases, English), though subsequent link clicks might be translated.
-However, there are some links (related content, amongst others) that we have hard-coded into the English to make them easier to analyse.
+We capture what language a page was written in in the `content_language` dimension. The majority of pages on GOV.UK are written in English, although there are a few pages in [Ukrainian](https://www.gov.uk/guidance/apply-for-a-ukraine-family-scheme-visa.uk), [Russian](https://www.gov.uk/guidance/apply-for-a-ukraine-family-scheme-visa.ru), and other languages.
+
+Separately, the user's browser language is captured in the `language` dimension.
+However, there are a number of ways users can translate page content - for example, using browser add-ons.
+If the browser is translating the page content after the `page_view` event is sent, then the `page_view` will be sent with details in the original language (in most cases, English), though the text and other dimensions sent with subsequent interactions on that page might be translated.
+
+There are a few dimensions that we have hard-coded in English to make them easier to analyse, for example the 'section' value on related content link clicks, but in most cases this was not possible due to the way content is surfaced via the Content API on GOV.UK.
 
 #### Issues with link domain information in navigation tracking on pages with mistyped URLs
 When there is an extra / in the URL, the 'Link domain' information is incorrect, coming through as the first part of the path instead of the domain.
-This can be seen on the live site, for example if you interact with links on the `https://www.gov.uk//guidance/cost-of-living-payment#low-income-benefits-and-tax-credits-cost-of-living-payment-eligibility` page.
-Strictly, this URL should not be valid, but it (and many other incorrect URLs) do work to load content on GOV.UK. 
+This can be seen on the live site, for example if you interact with the Contents links on the `https://www.gov.uk//guidance/cost-of-living-payment#low-income-benefits-and-tax-credits-cost-of-living-payment-eligibility` page.
+Strictly, this URL should not be valid, but it (and many other incorrect URLs) do work to load content on GOV.UK.
+
 Use of URLs like this is rare and so this should not cause too much of a data quality issue.
 
 #### Issues with publication and update dates

--- a/source/processes/ga4-resources/index.html.md.erb
+++ b/source/processes/ga4-resources/index.html.md.erb
@@ -3,6 +3,7 @@ title: GA4 resources
 weight: 10
 last_reviewed_on: 2024-02-13
 review_in: 6 months
+hide_in_navigation: true
 ---
 
 # GA4 resources


### PR DESCRIPTION
Updating GOV.UK GA4 data quality notes with information related to https://trello.com/c/MNYxe0cE/561-link-text-in-foreign-languages and https://trello.com/c/Chhv6G8s/696-update-implementation-guide-inconsistent-behaviour-with-regards-outbound-parameter-in-attachment-link-clicks-file-downloads bugs.

Also, hiding the now out-of-date 'GA4 resources' page, and moving some useful links and information from it to other pages.