### PR TITLE
Roadmap page updates

### DIFF
--- a/source/processes/govuk-ga-roadmap/ga-changelog/index.html.md.erb
+++ b/source/processes/govuk-ga-roadmap/ga-changelog/index.html.md.erb
@@ -7,7 +7,7 @@ hide_in_navigation: true
 ---
 
 # GOV.UK GA4 improvements changelog
-This page details improvements made to the [GOV.UK GA4 data collection](/data-sources/ga/ga4/) and [processing](/processes/ga4-data-processing/) since January 202s5.
+This page details improvements made to the [GOV.UK GA4 data collection](/data-sources/ga/ga4/) and [processing](/processes/ga4-data-processing/) since January 2025.
 
 Upcoming changes can be found on the [improvements roadmap page](/processes/govuk-ga-roadmap/).
 

--- a/source/processes/govuk-ga-roadmap/ga-changelog/index.html.md.erb
+++ b/source/processes/govuk-ga-roadmap/ga-changelog/index.html.md.erb
@@ -1,0 +1,22 @@
+---
+title: GOV.UK GA4 improvements changelog
+weight: 2
+last_reviewed_on: 2025-01-25
+review_in: 6 months
+hide_in_navigation: true
+---
+
+# GOV.UK GA4 improvements changelog
+This page details improvements made to the [GOV.UK GA4 data collection](/data-sources/ga/ga4/) and [processing](/processes/ga4-data-processing/) since January 202s5.
+
+Upcoming changes can be found on the [improvements roadmap page](/processes/govuk-ga-roadmap/).
+
+For a more long-term history, please see the [GOV.UK GA4 annotations report](/products/govuk-ga4-annotations/).
+
+## January 2025
+### New canonical URL field
+A page's canonical URL is captured in a new field/custom dimension sent with all events.
+This is available in the GOV.UK GA4 property, the Data API, and in BigQuery in both the raw and flattened datasets.
+
+### traffic_type parameter added to the GOV.UK GA4 flattened dataset
+The `traffic_type` parameter is available in the [GOV.UK GA4 flattened dataset](/data-sources/ga/ga4-flat/) to support analysis of GOV.UK GA4 data filters.

--- a/source/processes/govuk-ga-roadmap/index.html.md.erb
+++ b/source/processes/govuk-ga-roadmap/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 improvements roadmap
 weight: 2
-last_reviewed_on: 2025-01-14
+last_reviewed_on: 2025-01-25
 review_in: 6 months
 ---
 
@@ -9,9 +9,6 @@ review_in: 6 months
 This page details upcoming and recent changes to the [GOV.UK GA4 data collection](/data-sources/ga/ga4/) and [processing](/processes/ga4-data-processing/).
 
 ## What we're working on now
-### Adding the traffic_type parameter to the GOV.UK GA4 flattened dataset
-Adding the traffic_type parameter to the [GOV.UK GA4 flattened dataset](/data-sources/ga/ga4-flat/) to support analysis of GOV.UK GA4 data filters.
-
 ### Fixing issues with taxonomy dimensions in the GOV.UK GA4 flattened dataset
 Renaming taxonomy dimensions in the GOV.UK GA4 flattened dataset to ensure the correct page taxonomy information is readily available.
 
@@ -31,6 +28,9 @@ Updating a data filter set up in the GOV.UK GA4 property to more accurately labe
 ### New canonical URL field
 A page's canonical URL is captured in a new field/custom dimension sent with all events.
 This is available in the GOV.UK GA4 property, the Data API, and in BigQuery in both the raw and flattened datasets.
+
+### traffic_type parameter added to the GOV.UK GA4 flattened dataset
+The traffic_type parameter is available in the [GOV.UK GA4 flattened dataset](/data-sources/ga/ga4-flat/) to support analysis of GOV.UK GA4 data filters.
 
 ## Updates
 As we’re still at an early stage, our plans may shift.


### PR DESCRIPTION
Roadmap page updates - adding the changelog page and updating one now completed item - related to https://trello.com/c/Mww39Nb4/99-ga4-continuous-improvement-communicate-plan-for-q4-ga4-ci and https://trello.com/c/J42R2p8t/229-add-traffictype-parameter-to-govuk-ga4-flattened-dataset