### PR TITLE
Updating GA4 data quality note on Smokey/E2E tests

### DIFF
--- a/source/data-sources/ga/ga4/data-quality/index.html.md.erb
+++ b/source/data-sources/ga/ga4/data-quality/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 data quality
 weight: 1
-last_reviewed_on: 2025-01-23
+last_reviewed_on: 2025-02-04
 review_in: 6 months
 ---
 
@@ -36,12 +36,14 @@ In GA4, [traffic from known bots is automatically excluded](https://support.goog
 
 We do not know how much other bot traffic is being recorded in our data.
 
-#### Smokey tests
+#### Smokey and E2E tests
 
-Some [smoke tests](https://en.wikipedia.org/wiki/Smoke_testing_(software)) are run on Production GOV.UK, and sometimes the [smokey test](https://github.com/alphagov/smokey) bot triggers analytics data collection.
+Some bots are used by GOV.UK developers to test the Production GOV.UK site.
+These tests - the [smokey test](https://github.com/alphagov/smokey) bot until the end of November 2024, and from December 2024 the [E2E tests](https://github.com/alphagov/govuk-e2e-tests) - can trigger analytics data collection.
 
-These can be found and removed from the data by using the 'Test data filter name' dimension, which will be populated with 'Smokey' if the data is from a smokey test IP address.
+These can be found and removed from the data by using the 'Test data filter name' dimension, which will be populated with 'Smokey' if the data is from an automated test IP address.
 This constitutes a tiny amount of data, so is unlikely to impact analysis.
+Data collected on traffic from these test bots dropped off almost entirely from December 2024 with the switch to the E2E tests, and any hits from these tests should now only occur on the [Cookies on GOV.UK](https://www.gov.uk/help/cookies} and [A/B testing](https://www.gov.uk/help/ab-testing) pages.
 
 ### Users we miss 
 

--- a/source/processes/govuk-ga-roadmap/ga-changelog/index.html.md.erb
+++ b/source/processes/govuk-ga-roadmap/ga-changelog/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 improvements changelog
 weight: 2
-last_reviewed_on: 2025-01-23
+last_reviewed_on: 2025-02-04
 review_in: 6 months
 ---
 
@@ -29,3 +29,7 @@ We have now edited the processing so that integer and double type data will be i
 Four taxonomy dimensions have been renamed in the GOV.UK GA4 flattened dataset to help users find the correct fields.
 `taxonomy_all_DEPRECATED` has become `taxonomy_all` and `taxonomy_all_ids_DEPRECATED` has become `taxonomy_all_ids`, as these are the fields containing current taxonomy information.
 `full_taxonomy` has been renamed `full_taxonomy_DEPRECATED` and `full_taxonomy_ids` has been renamed `full_taxonomy_ids_DEPRECATED` because these fields have not been populated since November 2023.
+
+### Smokey test data filter updated with other test IP addresses
+The 'Smokey' data filter set up in the GOV.UK GA4 property has been updated with the IP addresses now used for the [E2E tests](https://github.com/alphagov/govuk-e2e-tests).
+The [GOV.UK GA4 data quality notes](/data-sources/ga/ga4/data-quality/#smokey-and-e2e-tests) contain further details on the potential test bot data being collected and notes on how to filter it out of reports.

--- a/source/processes/govuk-ga-roadmap/index.html.md.erb
+++ b/source/processes/govuk-ga-roadmap/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 improvements roadmap
 weight: 2
-last_reviewed_on: 2025-01-23
+last_reviewed_on: 2025-02-04
 review_in: 6 months
 ---
 
@@ -16,9 +16,6 @@ Reassessing and updating calculated page location, page path, and/or URL fields 
 
 ### Improving our backfilling processes 
 Improving our backfilling processes, focussing on developing a process for backfilling individual columns of the [GOV.UK GA4 flattened dataset](/data-sources/ga/ga4-flat/).
-
-### Updating our Smokey test data filter 
-Updating a data filter set up in the GOV.UK GA4 property to more accurately label [Smokey test](https://docs.publishing.service.gov.uk/manual/testing.html#smokey) data.
 
 ### Enabling easier access to site search data
 Creating simplified tables or views containing site search data in BigQuery.
@@ -45,6 +42,10 @@ Note that these fields have not yet been backfilled (an upcoming task), so histo
 Four taxonomy dimensions have been renamed in the GOV.UK GA4 flattened dataset to help users find the correct fields.
 `taxonomy_all_DEPRECATED` has become `taxonomy_all` and `taxonomy_all_ids_DEPRECATED` has become `taxonomy_all_ids`, as these are the fields containing current taxonomy information.
 `full_taxonomy` has been renamed `full_taxonomy_DEPRECATED` and `full_taxonomy_ids` has been renamed `full_taxonomy_ids_DEPRECATED` because these fields have not been populated since November 2023.
+
+### Smokey test data filter updated with other test IP addresses
+The 'Smokey' data filter set up in the GOV.UK GA4 property has been updated with the IP addresses now used for the [E2E tests](https://github.com/alphagov/govuk-e2e-tests).
+The [GOV.UK GA4 data quality notes](/data-sources/ga/ga4/data-quality/#smokey-and-e2e-tests) contain further details on the potential test bot data being collected and notes on how to filter it out of reports.
 
 ## Updates
 As we’re still at an early stage, our plans may shift.


### PR DESCRIPTION
Updating GOV.UK GA4 data quality note on Smokey/E2E tests, linked to https://trello.com/c/6zYTa1k8/217-update-smokey-now-e2e-data-filter-test-with-new-ip-addresses