### PR TITLE
Adding Search Console data source information

### DIFF
--- a/source/analysis/use-search-console/index.html.md.erb
+++ b/source/analysis/use-search-console/index.html.md.erb
@@ -1,24 +1,24 @@
 ---
-title: Use the GOV.UK Search Console data
+title: Use Search Console data
 weight: 35
-last_reviewed_on: 2024-11-27
+last_reviewed_on: 2025-02-25
 review_in: 6 months
 ---
 
-# Use the GOV.UK Search Console data
-Google Search Console provides data on searches that result in a page from www.gov.uk being displayed as part of the Google search results.
-This data can help you understand what terms users use to find content on GOV.UK, and how well certain pages perform on the search results page.
+# Use Search Console data
+Google Search Console provides data on searches that result in a page from a given domain being displayed as part of the Google search results.
+This data can help you understand what terms users use to find content on our sites, and how well certain pages perform on the search results page.
 
-This page provides some guidance on how to use the GOV.UK Search Console data, stored in [BigQuery](/tools/google-cloud-platform/bigquery/).
+This page provides some guidance on how to use Search Console data stored in [BigQuery](/tools/google-cloud-platform/bigquery/).
 
-More information on the data source itself can be found on the [data source page](/data-sources/gsc/).
+More information on the Search Console data available can be found on the [data source pages](/data-sources/gsc/).
 
-## Use the GOV.UK Search Console data in BigQuery
+## Use Search Console data in BigQuery
 
 You can choose to access and query the Search Console data directly in BigQuery.
 
 To do this, you will need access to view and query the data. 
-All users who are granted [permissions to access GOV.UK GA4 data](/processes/ga-access/) are also granted permissions to access the Search Console data. 
+All users who are granted [permissions to access GOV.UK GA4 data](/processes/ga-access/) are also granted permissions to access the GOV.UK Search Console data. 
 GDS users will be able to run queries in a range of projects in BigQuery, such as the [GA4 analytics project](/tools/google-cloud-platform/gcp-projects/#ga4-analytics) where the data is stored.
 Users from other organisations will need to query the data from a Google Cloud Platform project with billing owned by their organisation.
 
@@ -26,10 +26,11 @@ If you are new to BigQuery, you may find it helpful to review Google’s [docume
 
 ### Tables and fields
 
-Information on the two Search Console tables can be found on the [data source page](/data-sources/gsc/).
+Information on the two Search Console tables can be found on the [data source pages](/data-sources/gsc/).
 
 Queries can be returned with `null` values if they are rare. In these cases, the 'is_anonymized_query' field should be marked with this bool.
-The query field will be `null` when it is true to protect the privacy of users making the query. More information on this can be found in [Google's documentation on Search Console performance data filtering and limits](https://developers.google.com/search/blog/2022/10/performance-data-deep-dive#privacy-filtering).
+The query field will be `null` when it is true to protect the privacy of users making the query.
+More information on this can be found in [Google's documentation on Search Console performance data filtering and limits](https://developers.google.com/search/blog/2022/10/performance-data-deep-dive#privacy-filtering).
 
 ### Example query
 
@@ -50,15 +51,14 @@ ORDER BY
   impressions DESC
 ```
 
-
-## Use the GOV.UK Search Console data in Looker Studio
+## Use Search Console data in Looker Studio
 
 The Search Console data stored in BigQuery can be used in Looker Studio (and other reporting tools).
 To do this, you will need the ID of a Google Cloud Platform project with billing enabled that is owned by your organisation.
 
 ### Connecting to the BigQuery data
 
-If you are a member of GDS staff, please use the [shared data connections](https://trello.com/c/N8C3H9KT/55-looker-studio-data-sources).
+If you are a member of GDS staff trying to access the GOV.UK Search Console data, please use the [shared data connections](https://trello.com/c/N8C3H9KT/55-looker-studio-data-sources).
 
 If you are a member of another organsiation, we recommend you use a custom query to connect to BigQuery.
 You can do this in Looker Studio by:

--- a/source/data-sources/gsc/assetspublishing/index.html.md.erb
+++ b/source/data-sources/gsc/assetspublishing/index.html.md.erb
@@ -1,0 +1,89 @@
+---
+title: Assets Search Console
+weight: 10
+last_reviewed_on: 2025-02-25
+review_in: 6 months
+---
+
+# Assets Search Console
+The Assets Google Search Console (GSC) data provides information on searches that result in a page or file on assets.publishing.service.gov.uk being displayed as part of the Google search results.
+
+The Search Console instance for assets.publishing.service.gov.uk is owned by the Insights and Analytics team. 
+
+## Access
+Direct access to Search Console is limited to Search Console admins.
+
+GDS staff can contact the data engineering community on Slack for access to this data.
+
+### Location
+GSC data for the assets.publishing.service.gov.uk site is located in BigQuery in the `ga4-analytics-352613.searchconsole_assetspublishing` dataset, within the [GA4 analytics project](/tools/google-cloud-platform/gcp-projects/#ga4-analytics).
+This data is stored in the europe-west 2 region (London).
+
+The dataset contains two partitioned tables.
+The `searchdata_site_impression` table contains performance data for the Assets property aggregated at the site/property level.
+The `searchdata_url_impression` table contains performance data for aggregated by URL.
+More information on Search Console data can be found in [Google's documentation](https://support.google.com/webmasters/answer/12917991?hl=en).
+
+## Schema
+### Site Impressions
+| field name | type | mode |
+| --- | --- | --- |
+| data_date | DATE | YES |
+| site_url | STRING | YES |
+| query | STRING | YES |
+| is_anonymized_query | BOOL | YES |
+| country | STRING | YES |
+| search_type | STRING | YES |
+| device | STRING | YES |
+| impressions | INT64 | YES |
+| clicks | INT64 | YES |
+| sum_top_position | INT64 | YES |
+
+
+### URL Impressions
+| field name | type | mode |
+| --- | --- | --- |
+| data_date | DATE | YES |
+| site_url | STRING | YES |
+| url | STRING | YES |
+| query | STRING | YES |
+| is_anonymized_query | BOOL | YES |
+| is_anonymized_discover | BOOL | YES |
+| country | STRING | YES |
+| search_type | STRING | YES |
+| device | STRING | YES |
+| is_amp_top_stories | BOOL | YES |
+| is_amp_blue_link | BOOL | YES |
+| is_job_listing | BOOL | YES |
+| is_job_details | BOOL | YES |
+| is_tpf_qa | BOOL | YES |
+| is_tpf_faq | BOOL | YES |
+| is_tpf_howto | BOOL | YES |
+| is_weblite | BOOL | YES |
+| is_action | BOOL | YES |
+| is_events_listing | BOOL | YES |
+| is_events_details | BOOL | YES |
+| is_search_appearance_android_app | BOOL | YES |
+| is_amp_story | BOOL | YES |
+| is_amp_image_result | BOOL | YES |
+| is_video | BOOL | YES |
+| is_organic_shopping | BOOL | YES |
+| is_review_snippet | BOOL | YES |
+| is_special_announcement | BOOL | YES |
+| is_recipe_feature | BOOL | YES |
+| is_recipe_rich_snippet | BOOL | YES |
+| is_subscribed_content | BOOL | YES |
+| is_page_experience | BOOL | YES |
+| is_practice_problems | BOOL | YES |
+| is_math_solvers | BOOL | YES |
+| is_translated_result | BOOL | YES |
+| is_edu_q_and_a | BOOL | YES |
+| is_product_snippets | BOOL | YES |
+| is_merchant_listings | BOOL | YES |
+| is_learning_videos | BOOL | YES |
+| impressions | INT64 | YES |
+| clicks | INT64 | YES |
+| sum_position | INT64 | YES |
+
+## Retention
+No data retention period has yet been specified in BigQuery.

--- a/source/data-sources/gsc/index.html.md.erb
+++ b/source/data-sources/gsc/index.html.md.erb
@@ -1,97 +1,19 @@
 ---
 title: Google Search Console
 weight: 5
-last_reviewed_on: 2024-06-08
+last_reviewed_on: 2025-02-25
 review_in: 6 months
 ---
 
 # Google Search Console
 
-Google Search Console (GSC) provides data on searches that result in a page from www.gov.uk being displayed as part of the Google search results.
+Google Search Console (GSC) provides data on searches that result in a page from a given domain being displayed as part of the Google search results.
 
 Search Console also allows you to remove content items from external search results and clear caches.
 These features are used by Technical 2nd line.
 
-The Search Console instance for www.gov.uk is owned by the Analytics team. 
+The Google Search Console properties with BigQuery exports set up are documented below this page. 
+See the documentation for information on the location and content of these datasets, and policies for access:
 
-Information on how to use the GOV.UK Search Console data can be found in the [Analysis section](/analysis/use-search-console/).
-
-## Access
-Direct access to Search Console is limited to Search Console admins.
-
-Access to query the data stored in BigQuery is automatically granted to everyone with access to the GOV.UK GA4 data.
-More information can be found in our [GA access policy](/processes/ga-access/#what-we-provide-access-to).
-
-### Location
-
-GSC data for the www.gov.uk site is located in BigQuery in the `ga4-analytics-352613.searchconsole_wwwgovuk` dataset, within the [GA4 analytics project](/tools/google-cloud-platform/gcp-projects/#ga4-analytics).
-There are two partitioned tables: `searchdata_site_impression` and `searchdata_url_impression`. 
-The `searchdata_site_impression` table contains performance data for our GOV.UK property aggregated at the site/property level.
-The `searchdata_url_impression` table contains performance data for aggregated by URL.
-More information on Search Console data can be found in [Google's documentation](https://support.google.com/webmasters/answer/12917991?hl=en).
-
-For more information on the Google Cloud Platform projects, see our [GCP Project Documentation](/tools/google-cloud-platform/gcp-projects).
-
-
-## Schema
-### Site Impressions
-| field name | type | mode |
-| --- | --- | --- |
-| data_date | DATE | YES |
-| site_url | STRING | YES |
-| query | STRING | YES |
-| is_anonymized_query | BOOL | YES |
-| country | STRING | YES |
-| search_type | STRING | YES |
-| device | STRING | YES |
-| impressions | INT64 | YES |
-| clicks | INT64 | YES |
-| sum_top_position | INT64 | YES |
-
-
-### URL Impressions
-| field name | type | mode |
-| --- | --- | --- |
-| data_date | DATE | YES |
-| site_url | STRING | YES |
-| url | STRING | YES |
-| query | STRING | YES |
-| is_anonymized_query | BOOL | YES |
-| is_anonymized_discover | BOOL | YES |
-| country | STRING | YES |
-| search_type | STRING | YES |
-| device | STRING | YES |
-| is_amp_top_stories | BOOL | YES |
-| is_amp_blue_link | BOOL | YES |
-| is_job_listing | BOOL | YES |
-| is_job_details | BOOL | YES |
-| is_tpf_qa | BOOL | YES |
-| is_tpf_faq | BOOL | YES |
-| is_tpf_howto | BOOL | YES |
-| is_weblite | BOOL | YES |
-| is_action | BOOL | YES |
-| is_events_listing | BOOL | YES |
-| is_events_details | BOOL | YES |
-| is_search_appearance_android_app | BOOL | YES |
-| is_amp_story | BOOL | YES |
-| is_amp_image_result | BOOL | YES |
-| is_video | BOOL | YES |
-| is_organic_shopping | BOOL | YES |
-| is_review_snippet | BOOL | YES |
-| is_special_announcement | BOOL | YES |
-| is_recipe_feature | BOOL | YES |
-| is_recipe_rich_snippet | BOOL | YES |
-| is_subscribed_content | BOOL | YES |
-| is_page_experience | BOOL | YES |
-| is_practice_problems | BOOL | YES |
-| is_math_solvers | BOOL | YES |
-| is_translated_result | BOOL | YES |
-| is_edu_q_and_a | BOOL | YES |
-| is_product_snippets | BOOL | YES |
-| is_merchant_listings | BOOL | YES |
-| is_learning_videos | BOOL | YES |
-| impressions | INT64 | YES |
-| clicks | INT64 | YES |
-| sum_position | INT64 | YES |
-
-## Retention
+- [Search Console data for www.gov.uk](/data-sources/gsc/wwwgovuk)
+- [Search Console data for assets.publishing.service.gov.uk](/data-sources/gsc/assetspublishing)

--- a/source/data-sources/gsc/wwwgovuk/index.html.md.erb
+++ b/source/data-sources/gsc/wwwgovuk/index.html.md.erb
@@ -1,0 +1,92 @@
+---
+title: GOV.UK Search Console
+weight: 5
+last_reviewed_on: 2025-02-25
+review_in: 6 months
+---
+
+# GOV.UK Search Console
+The GOV.UK Google Search Console (GSC) data provides information on searches that result in a page from [www.gov.uk](https://www.gov.uk/) being displayed as part of the Google search results.
+
+The Search Console instance for www.gov.uk is owned by the Insights and Analytics team. 
+
+Information on how to use the GOV.UK Search Console data can be found in the [Analysis section](/analysis/use-search-console/).
+
+## Access
+Direct access to Search Console is limited to Search Console admins.
+
+Access to query the [www.gov.uk](https://www.gov.uk/) Search Console data stored in BigQuery is automatically granted to everyone with access to the GOV.UK GA4 data.
+More information can be found in our [GA access policy](/processes/ga-access/#what-we-provide-access-to).
+
+### Location
+GSC data for the www.gov.uk site is located in BigQuery in the `ga4-analytics-352613.searchconsole_wwwgovuk` dataset, within the [GA4 analytics project](/tools/google-cloud-platform/gcp-projects/#ga4-analytics).
+This data is stored in the europe-west 2 region (London).
+
+The dataset contains two partitioned tables.
+The `searchdata_site_impression` table contains performance data for the GOV.UK property aggregated at the site/property level.
+The `searchdata_url_impression` table contains performance data for aggregated by URL.
+More information on Search Console data can be found in [Google's documentation](https://support.google.com/webmasters/answer/12917991?hl=en).
+
+## Schema
+### Site Impressions
+| field name | type | mode |
+| --- | --- | --- |
+| data_date | DATE | YES |
+| site_url | STRING | YES |
+| query | STRING | YES |
+| is_anonymized_query | BOOL | YES |
+| country | STRING | YES |
+| search_type | STRING | YES |
+| device | STRING | YES |
+| impressions | INT64 | YES |
+| clicks | INT64 | YES |
+| sum_top_position | INT64 | YES |
+
+
+### URL Impressions
+| field name | type | mode |
+| --- | --- | --- |
+| data_date | DATE | YES |
+| site_url | STRING | YES |
+| url | STRING | YES |
+| query | STRING | YES |
+| is_anonymized_query | BOOL | YES |
+| is_anonymized_discover | BOOL | YES |
+| country | STRING | YES |
+| search_type | STRING | YES |
+| device | STRING | YES |
+| is_amp_top_stories | BOOL | YES |
+| is_amp_blue_link | BOOL | YES |
+| is_job_listing | BOOL | YES |
+| is_job_details | BOOL | YES |
+| is_tpf_qa | BOOL | YES |
+| is_tpf_faq | BOOL | YES |
+| is_tpf_howto | BOOL | YES |
+| is_weblite | BOOL | YES |
+| is_action | BOOL | YES |
+| is_events_listing | BOOL | YES |
+| is_events_details | BOOL | YES |
+| is_search_appearance_android_app | BOOL | YES |
+| is_amp_story | BOOL | YES |
+| is_amp_image_result | BOOL | YES |
+| is_video | BOOL | YES |
+| is_organic_shopping | BOOL | YES |
+| is_review_snippet | BOOL | YES |
+| is_special_announcement | BOOL | YES |
+| is_recipe_feature | BOOL | YES |
+| is_recipe_rich_snippet | BOOL | YES |
+| is_subscribed_content | BOOL | YES |
+| is_page_experience | BOOL | YES |
+| is_practice_problems | BOOL | YES |
+| is_math_solvers | BOOL | YES |
+| is_translated_result | BOOL | YES |
+| is_edu_q_and_a | BOOL | YES |
+| is_product_snippets | BOOL | YES |
+| is_merchant_listings | BOOL | YES |
+| is_learning_videos | BOOL | YES |
+| impressions | INT64 | YES |
+| clicks | INT64 | YES |
+| sum_position | INT64 | YES |
+
+## Retention
+No data retention period has yet been specified in BigQuery.

--- a/source/data-sources/index.html.md.erb
+++ b/source/data-sources/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Data sources
 weight: 40
-last_reviewed_on: 2025-02-19
+last_reviewed_on: 2025-02-25
 review_in: 6 months
 ---
 
@@ -20,7 +20,8 @@ These include:
 - [www.gov.uk flattened Universal Analytics data in BigQuery](/data-sources/ga/ua-flat/)
 - [GOV.UK GA4 usage logs](/data-sources/ga/ga4-logs/)
 - [GA settings database](/data-sources/ga/ga-settings/)
-- [Google Search Console for GOV.UK](/data-sources/gsc/)
+- [Google Search Console for GOV.UK](/data-sources/gsc/wwwgovuk)
+- [Google Search Console for the Assets domain](/data-sources/gsc/assetspublishing)
 - [Google Cloud Platform logs](/data-sources/gcp-logs/)
 - [GOV.UK Knowledge Graph](/data-sources/govgraph/), also known as as GovGraph
 - [GOV.UK User Feedback](/data-sources/user-feedback/)

--- a/source/products/content-data/index.html.md.erb
+++ b/source/products/content-data/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Content Data app
 weight: 34
-last_reviewed_on: 2024-11-21
+last_reviewed_on: 2025-02-25
 review_in: 6 months
 ---
 
@@ -35,7 +35,7 @@ The table below reveals potential differences when looking at Content Data over 
 | Field name | Definition pre-December 2023 (UA) | Definition since December 2023 (GA4) | Notes |
 | --- | --- | --- | --- |
 | Unique page views | The [`uniquePageviews` metric returned from the API](https://github.com/alphagov/content-data-api/pull/2005/commits/e474afb5f727e778466ba4ee277a9a884191e1ff#diff-f889fa6dea35fd3a8d5b23c9341a0aeadc5eb52fca2d293a3f6c6c59397b05ecL86) | A count of distinct session IDs attached to page_view events on the page in question | The figures returned will differ between UA and GA4 due to the [change in the definition of a session](/analysis/govuk-ga4/understand-ua-differences/#sessions) |
-| Page views | The total number of page views the selected page received in the given period - the [`pageviews` metric returned from the API](https://github.com/alphagov/content-data-api/pull/2005/commits/e474afb5f727e778466ba4ee277a9a884191e1ff#diff-f889fa6dea35fd3a8d5b23c9341a0aeadc5eb52fca2d293a3f6c6c59397b05ecL85) | The total number of page views the selected page received in the given period - a count of distinct session IDs attached to page_view events on the page in question | Should be very similar across UA and GA4 |
+| Page views | The total number of page views the selected page received in the given period - the [`pageviews` metric returned from the API](https://github.com/alphagov/content-data-api/pull/2005/commits/e474afb5f727e778466ba4ee277a9a884191e1ff#diff-f889fa6dea35fd3a8d5b23c9341a0aeadc5eb52fca2d293a3f6c6c59397b05ecL85) | The total number of page views the selected page received in the given period - a count of session IDs attached to page_view events on the page in question | Should be very similar across UA and GA4 |
 | Page views per visit |  | The number of total page views divided by the number of unique page views, to show on average how many times a page was viewed during a user's session | The figures returned will differ between UA and GA4 due to the [change in the definition of a session](/analysis/govuk-ga4/understand-ua-differences/#sessions) |
 | Searches from page | The [`searchUniques` metric returned from the API](https://github.com/alphagov/content-data-api/pull/2064/files#diff-ffdec38327091d6fe4265ad5e83274af06090b43cbf3aee0ba46ecbf9c2d247aL74) where the page in question was the `searchStartPage` | The number of `search` events sent on the page | These are potentially quite different metrics |
 | Number of feedback comments | The number of [Feedex comments returned from the support API](https://github.com/alphagov/content-data-api/blob/main/app/domain/etl/feedex/service.rb#L44) | No change | Data from Feedex - not impacted by the migration to GA4 |


### PR DESCRIPTION
Adding and updating Search Console data source information, particularly linked to the new Search Console data source for the assets.publishing domain (https://trello.com/c/7XBuGJfA/345-set-up-assets-domain-search-console-bigquery-export), plus a small fix to correct some Content Data information 