### PR TITLE
Revert "Update deploy.yml to ruby 3.1"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.0'
+          ruby-version: '2.7.6'
 
       - name: Ruby gem cache
         uses: actions/cache@v4


### PR DESCRIPTION
Reverts alphagov/data-community-tech-docs#258

The way that we fixed local preview (#340) was by updating the Gemfile.lock versions to the ones in the upstream https://github.com/alphagov/tech-docs-template. That works with Ruby v2.6.7. So I'm reluctant to upgrade Ruby to v3.1.0 for previewing locally, and somehow _downgrading_ Ruby in the workflow from v3.1.0 to v2.6.7 seems like the right thing to try.

There is a makefile, which isn't mentioned in the README, and isn't used anywhere else. It might be being used for local preview by some users of this repo, so we won't interfere with it in this PR by changing its version of Ruby.