### PR TITLE
Install the same version of bundler as in README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Install Gems
         run: |
+          gem install bundler:1.16.5
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 


### PR DESCRIPTION
The steps in the README to preview the site locally currently work, but the GitHub Action to deploy the site doesn't work, due to version conflicts.

The only step that the README does that the workflow doesn't is `gem install bundler:1.16.5`, so this PR adds that step to the workflow 🤞