### PR TITLE
Adding notes on session_start and page_view event oddities

### DIFF
--- a/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
@@ -81,9 +81,10 @@ If a user leaves www.gov.uk to go to another website but returns to www.gov.uk w
 A single user can open multiple sessions.
 If John Smith visits GOV.UK in the same browser on his laptop on Friday and Saturday, that will be counted as one “user” having two sessions.
 
-Sessions can be counted using the `session_start` event.
+When a new session is started, the `session_start` event will fire.
+Sessions can be counted either using this event or using the session ID (though these two methods tend to lead to very slightly different results).
 
-We have sometimes noticed sessions which are missing session_start events.
+We have sometimes noticed sessions which appear to be missing session_start events.
 If a user starts a session just before midnight but continues activity after midnight, analysis of the new day will show user engagement in a session that does not contain a session_start event.
 About 0.3% of our sessions are like this.
 

--- a/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Understand key GA4 dimensions and metrics
 weight: 3
-last_reviewed_on: 2025-02-28
+last_reviewed_on: 2025-04-22
 review_in: 6 months
 ---
 
@@ -81,10 +81,26 @@ If a user leaves www.gov.uk to go to another website but returns to www.gov.uk w
 A single user can open multiple sessions.
 If John Smith visits GOV.UK in the same browser on his laptop on Friday and Saturday, that will be counted as one “user” having two sessions.
 
+Sessions can be counted using the `session_start` event.
+
+We have sometimes noticed sessions which are missing session_start events.
+If a user starts a session just before midnight but continues activity after midnight, analysis of the new day will show user engagement in a session that does not contain a session_start event.
+About 0.3% of our sessions are like this.
+
+A rarer occurance (about 0.1% of sessions) are sessions with more than one session_start events.
+
 ### Event count
 
 GA4 data is structured around [events](https://support.google.com/analytics/answer/9322688?hl=en#zippy=%2Crealtime-report%2Cdebugview-report).
 The event count represents a non-distict count of events.
+
+### Page views
+
+Views are a specific type of event count, counting `page_view` (or `screen_view`) events.
+
+Note that about 4% of sessions on GOV.UK do not have a `page_view` event.
+This is likely due to users opening pages and returning to them hours later.
+In GA4, this will appear as a session with a `page_view` event, followed hours later by a new session containing a `user_engagement` event but no `page_view` on that page.
 
 ### Engagement metrics
 


### PR DESCRIPTION
Adding notes on session_start and page_view event oddities from @paulcronk's work related to https://trello.com/c/MSx1jSXx/180-investigate-sessions-with-no-pageview-events