### PR TITLE
Indexes data quality note

### DIFF
--- a/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/understand-ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Understand key GA4 dimensions and metrics
 weight: 3
-last_reviewed_on: 2025-02-28
+last_reviewed_on: 2025-04-22
 review_in: 6 months
 ---
 
@@ -81,10 +81,26 @@ If a user leaves www.gov.uk to go to another website but returns to www.gov.uk w
 A single user can open multiple sessions.
 If John Smith visits GOV.UK in the same browser on his laptop on Friday and Saturday, that will be counted as one “user” having two sessions.
 
+Sessions can be counted using the `session_start` event.
+
+We have sometimes noticed sessions which are missing session_start events.
+If a user starts a session just before midnight but continues activity after midnight, analysis of the new day will show user engagement in a session that does not contain a session_start event.
+About 0.3% of our sessions are like this.
+
+A rarer occurance (about 0.1% of sessions) are sessions with more than one session_start events.
+
 ### Event count
 
 GA4 data is structured around [events](https://support.google.com/analytics/answer/9322688?hl=en#zippy=%2Crealtime-report%2Cdebugview-report).
 The event count represents a non-distict count of events.
+
+### Page views
+
+Views are a specific type of event count, counting `page_view` (or `screen_view`) events.
+
+Note that about 4% of sessions on GOV.UK do not have a `page_view` event.
+This is likely due to users opening pages and returning to them hours later.
+In GA4, this will appear as a session with a `page_view` event, followed hours later by a new session containing a `user_engagement` event but no `page_view` on that page.
 
 ### Engagement metrics
 

--- a/source/data-sources/ga/ga4/data-quality/index.html.md.erb
+++ b/source/data-sources/ga/ga4/data-quality/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 data quality
 weight: 1
-last_reviewed_on: 2025-02-04
+last_reviewed_on: 2025-04-22
 review_in: 6 months
 ---
 
@@ -130,3 +130,11 @@ Due to GA4's character count limits on parameter values (previously set to 100 c
 To work around this, in February 2023 we implemented a solution which split these fields across five sub-fields, which were then concatenated togeter in the `full_taxonomy` and `full_taxonomy_ids` fields, and the `taxonomy_all` and `taxonomy_all_ids` fields were left empty.
 Later in 2023, Google increased the character count limit on parameter values to 500, so in November we switched back to the `taxonomy_all` and `taxonomy_all_ids` fields.
 We have renamed the 'full' taxonomy fields to `full_taxonomy_DEPRECATED` and `full_taxonomy_ids_DEPRECATED` as they are now not being populated (since November 2023), although they still contain the data for February to November 2023 should that be required.
+
+#### Issues with indexes
+
+Early on in the development of our GOV.UK GA4 tracking, only two index fields - the `index` and `index_total` - were collected.
+This was expanded in March 2023 so there are now four fields, collecting the index_link (the index of the clicked item, often a link, within the section), index_total (the total number of links or items in the section), index_section (the index of the section that was interacted with), and index_section_count (the total number of sections in the thing being tracked).
+
+Index information, which would typically be sent with some `select_content` and some `navigation` events, is missing from some events due to difficulties implementing the tracking.
+For example, the `index_section_count` is not collected from detail type events on certain document types.


### PR DESCRIPTION
Adding a GOV.UK GA4 data quality note, related to https://trello.com/c/2nhQfMwl/848-fix-details-missing-indexsectioncount-across-various-formats