### PR TITLE
add Publishing GA4 user admin tool info

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,6 @@ The documentation is [© Crown copyright][copyright] and available under the ter
 [example-content]: https://tdt-documentation.london.cloudapps.digital/content.html#content-examples
 [partials]: https://tdt-documentation.london.cloudapps.digital/single_page.html#add-partial-lines
 [install-ruby]: https://tdt-documentation.london.cloudapps.digital/install_macs.html#install-ruby
-[install-middleman]: https://tdt-documentation.london.cloudapps.digital/install_macs.html#install-middleman
+[install-middleman]: https://github.com/middleman/middleman?tab=readme-ov-file#installation
 [gem]: https://github.com/alphagov/tech-docs-gem
 [template]: https://github.com/alphagov/tech-docs-template

--- a/source/tools/ga4-user-admin-tool/index.html.md.erb
+++ b/source/tools/ga4-user-admin-tool/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GA4 User Admin tool
 weight: 6
-last_reviewed_on: 2024-11-27
+last_reviewed_on: 2025-05-07
 review_in: 6 months
 ---
 
@@ -55,3 +55,8 @@ The tool is hosted [here](https://34.36.39.60.nip.io/) and is deployed from the 
 The Blogs GA4 User Admin tool is used to add and delete users' access to www.blog.gov.uk production Google Analytics data (the Google Analytics property only).
 
 The tool is located [here](https://34.49.209.228.nip.io/).
+
+### GA4 Publishing User Admin tool
+The Publishing GA4 User Admin tool is used to add and delete users' access to the Publishing GA4 property.
+
+The tool is located [here](https://34.54.233.238.nip.io/).


### PR DESCRIPTION
- add a description and link for the Publishing GA4 Property User Admin tool.
- update Middleman installation link as previous link was broken.