### PR TITLE
Adding GA4 definitions plus batch_event_index note

### DIFF
--- a/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
@@ -289,13 +289,13 @@ Using the BigQuery data, however, you can view users' journeys in much more deta
 
 ### Ordering users' events
 
-There is no 'hit number' in the GA4 data which easily enables you to order a user's events.
-Instead, there are a number of other dimensions that will need to be used to carry out this ordering.
+There is no one 'hit number' dimension in the GA4 data which easily enables you to order a user's events.
+Instead, there are a number of other dimensions that can be combined to carry out this ordering.
 These include:
 
 - the `event_timestamp` - this is a default dimension and represents the time that a given batch of events was sent to GA4. As this is connected to the event batch (Google batches events that occur within a few seconds of each other), many events can have the same event_timestamp
 - the `timestamp` - this is a custom dimension which captures the time that a given event is sent to the dataLayer. This should be a better indicator of the actual time an event occurred than the `event_timestamp`, but some events may still have identical `timestamp` values (particularly: the automatic events Google generate such as `session_start` will have identical timestamps to the session's first `page_view`). We implemented this in mid January 2024 so this can only be used for ordering events after that date
-- the `batch_ordering_id` and `batch_event_index` - these are default dimensions indicating what order batches were logged in and what order events were logged within a batch. These indexes were only added to GA4 datasets in [mid-July 2024](https://support.google.com/analytics/answer/9164320#071624) so can only be used after that date
+- the `batch_ordering_id` and `batch_event_index` - these are default dimensions indicating what order batches were logged in and what order events were logged within a batch. These indexes were only added to GA4 datasets in [mid-July 2024](https://support.google.com/analytics/answer/9164320#071624) so can only be used to order events collected after that date
 
 Google provide some sample code indicating how you can use some combination of these IDs and indexes to order users' events in [their guidance](https://developers.google.com/analytics/bigquery/basic-queries#sequence_of_pageviews).
 

--- a/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Find things in the GOV.UK GA4 data
 weight: 6
-last_reviewed_on: 2024-12-11
+last_reviewed_on: 2025-08-06
 review_in: 6 months
 ---
 
@@ -287,11 +287,19 @@ Google have published some information on how to use [funnel explorations here](
 
 Using the BigQuery data, however, you can view users' journeys in much more detail.
 
-### Using the custom `timestamp`
+### Ordering users' events
 
-In the absence of a hit number sent with each GA4 event, we implemented a custom timestamp which can be used to order a user's events.
+There is no 'hit number' in the GA4 data which easily enables you to order a user's events.
+Instead, there are a number of other dimensions that will need to be used to carry out this ordering.
+These include:
 
-We implemented this in January 2024, so this cannot be used to order events before then.
+- the `event_timestamp` - this is a default dimension and represents the time that a given batch of events was sent to GA4. As this is connected to the event batch (Google batches events that occur within a few seconds of each other), many events can have the same event_timestamp
+- the `timestamp` - this is a custom dimension which captures the time that a given event is sent to the dataLayer. This should be a better indicator of the actual time an event occurred than the `event_timestamp`, but some events may still have identical `timestamp` values (particularly: the automatic events Google generate such as `session_start` will have identical timestamps to the session's first `page_view`). We implemented this in mid January 2024 so this can only be used for ordering events after that date
+- the `batch_ordering_id` and `batch_event_index` - these are default dimensions indicating what order batches were logged in and what order events were logged within a batch. These indexes were only added to GA4 datasets in [mid-July 2024](https://support.google.com/analytics/answer/9164320#071624) so can only be used after that date
+
+Google provide some sample code indicating how you can use some combination of these IDs and indexes to order users' events in [their guidance](https://developers.google.com/analytics/bigquery/basic-queries#sequence_of_pageviews).
+
+From our investigations, we believe that the 'batch_event_index' is the most reliable way to order hits on a given page (that are likely to have occurred within a batch).
 
 #### Method in BigQuery
 
@@ -302,28 +310,22 @@ SELECT
   #Create a session ID
   CONCAT(user_pseudo_id,"-", ga_sessionid) AS session_id,
   page_location,
+  event_name,
+  event_timestamp,
   timestamp,
-  #Calculate a 'hit number' based on the timestamp
-  ROW_NUMBER() OVER (PARTITION BY CONCAT(user_pseudo_id, "-", ga_sessionid) ORDER BY timestamp ASC) AS hit_number,
+  batch_event_index,
+  #Calculate a 'hit number' based on the event_timestamp and batch_event_index
+  ROW_NUMBER() OVER (PARTITION BY CONCAT(user_pseudo_id, "-", ga_sessionid) ORDER BY event_timestamp, batch_event_index ASC) AS hit_number,
 FROM
   `ga4-analytics-352613.flattened_dataset.partitioned_flattened_events`
 WHERE
-  #Page views only
-  event_name="page_view"
-  AND event_date = '2024-08-26'
+  event_date = '2024-08-26'
 ORDER BY
   session_id,
-  timestamp
+  hit_number
 ```
 
 The result of this query could be further manipulated to enable analysis of users' journeys.
-
-### Using the built-in `batch_event_index`
-
-Google added batch ordering IDs to the GA4 dataset in [mid-July 2024](https://support.google.com/analytics/answer/9164320#071624).
-
-Google provide some sample code indicating how you can use these IDs to order users' events in [their guidance](https://developers.google.com/analytics/bigquery/basic-queries#sequence_of_pageviews).
-
 
 ## Engagement
 

--- a/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
@@ -303,7 +303,7 @@ From our investigations, we believe that the 'batch_event_index' is the most rel
 
 #### Method in BigQuery
 
-The following SQL gets all page views on 26th August 2024, with a calculated 'session ID' and 'hit number', ordered by the session ID and custom timestamp:
+The following SQL gets all page views on 26th August 2024, with a calculated 'session ID' and 'hit number', ordered by the session ID using the `event_timestamp` and `batch_event_index`:
 
 ```SQL
 SELECT

--- a/source/data-sources/ga/ga4-flat/index.html.md.erb
+++ b/source/data-sources/ga/ga4-flat/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 flattened table
 weight: 3
-last_reviewed_on: 2025-05-29
+last_reviewed_on: 2025-08-06
 review_in: 6 months
 ---
 
@@ -99,7 +99,7 @@ More information on the processing can be found in the [Policies and processes s
 | full_taxonomy_ids_DEPRECATED | STRING | NULLABLE | Deprecated - the taxonomy ID path parts, concatenated. This field was [only populated between February and November 2023](/data-sources/ga/ga4/data-quality/#issues-with-taxonomy-information). Users seeking this information outside that period should use the `taxonomy_all_ids` field |
 | rendering_app | STRING | NULLABLE | The content attribute of the `<meta name="govuk:rendering-app">` tag |
 | organisations | STRING | NULLABLE | Publishing organisation IDs - the content attribute of the `<meta name="govuk:analytics:organisations">` tag e.g. '\<D25>' |
-| session_engaged | STRING | NULLABLE |  |
+| session_engaged | STRING | NULLABLE | A flag to indicate whether or not the session was engaged e.g. '1' when the event belongs to a session deemed to be engaged. This begins as '0' for all events in a given session then flips to '1' for all events after the session has become engaged |
 | schema_name | STRING | NULLABLE | The content attribute of the `<meta name="govuk:schema-name">` tag |
 | method | STRING | NULLABLE | The method with which the user clicked on the link e.g. 'primary click'. Populated for navigation and information_click events only |
 | engagement_time_msec | INTEGER | NULLABLE | The time the user has been engaged in milliseconds |
@@ -109,7 +109,7 @@ More information on the processing can be found in the [Policies and processes s
 | event_source | STRING | NULLABLE | The source information [associated with this event](https://support.google.com/analytics/answer/11080067) |
 | session_source | STRING | NULLABLE | The source information [associated with this session](https://support.google.com/analytics/answer/11080067) (the first source of the session) |
 | link_text | STRING | NULLABLE | The text of the link clicked (sent with navigation and information_click events) |
-| term | STRING | NULLABLE | |
+| term | STRING | NULLABLE | Broken field that we are investigating. Do not use |
 | link_url | STRING | NULLABLE | The href attribute of a link (sent with navigation and information_click events) |
 | event_medium | STRING | NULLABLE | The medium information [associated with this event](https://support.google.com/analytics/answer/11080067) |
 | session_medium | STRING | NULLABLE | The medium information [associated with this session](https://support.google.com/analytics/answer/11080067) (the first medium of the session) |
@@ -117,7 +117,7 @@ More information on the processing can be found in the [Policies and processes s
 | event_previous_timestamp | INTEGER | NULLABLE | The time (in microseconds, UTC) the event was previously logged on the client |
 | event_bundle_sequence_id | INTEGER | NULLABLE | The sequential ID of the bundle in which these events were sent to GA4 |
 | event_server_timestamp_offset | INTEGER | NULLABLE | Timestamp offset between collection time and upload time in microseconds |
-| user_id | STRING | NULLABLE | |
+| user_id | STRING | NULLABLE | A unique ID to associate a single user with engagement via multiple devices. Not in use on GOV.UK |
 | user_first_touch_timestamp | INTEGER | NULLABLE | The time (in microseconds) when the user first visited the site |
 | category | STRING | NULLABLE | The device category (mobile, tablet, desktop) |
 | mobile_brand_name | STRING | NULLABLE | The device brand name |
@@ -129,8 +129,8 @@ More information on the processing can be found in the [Policies and processes s
 | language | STRING | NULLABLE | The OS language |
 | is_limited_ad_tracking | STRING | NULLABLE | The device's Limit Ad Tracking setting |
 | time_zone_offset_seconds | INTEGER | NULLABLE | The offset from GMT in seconds |
-| device_browser | STRING | NULLABLE | |
-| device_browser_version | STRING | NULLABLE | |
+| device_browser | STRING | NULLABLE | Not in use - use 'browser' field instead |
+| device_browser_version | STRING | NULLABLE | Not in use - use 'browser_version' field instead |
 | browser | STRING | NULLABLE | The browser in which the user viewed content |
 | browser_version | STRING | NULLABLE | The version of the browser in which the user viewed content |
 | hostname | STRING | NULLABLE | The hostname associated with the logged event |
@@ -145,8 +145,8 @@ More information on the processing can be found in the [Policies and processes s
 | first_user_source | STRING | NULLABLE | The source through which this user first landed on GOV.UK |
 | stream_id | STRING | NULLABLE | The numeric ID of the data stream from which the event originated |
 | platform | STRING | NULLABLE | The data stream platform (Web, IOS or Android) from which the event originated |
-| event_dimensions_hostname | STRING | NULLABLE | |
-| full_link_URL | STRING | NULLABLE | |
+| event_dimensions_hostname | STRING | NULLABLE | Not in use |
+| full_link_URL | STRING | NULLABLE | Should no longer be used - the link path parts, concatenated. This field was [only correctly populated between February and November 2023](/data-sources/ga/ga4/data-quality/#issues-with-the-full-link-URL). Users seeking this information outside that period should use the `link_url` field |
 | search_sort | STRING | NULLABLE | Where available this is the sort method e.g. 'Relevance' |
 | search_term | STRING | NULLABLE | The search term used |
 | search_results | STRING | NULLABLE | The number of results returned by the search |
@@ -159,28 +159,28 @@ More information on the processing can be found in the [Policies and processes s
 | publishing_government | STRING | NULLABLE | The content attribute of the `<meta name="govuk:political-status">` tag e.g. 'historic'. This will only be available on 'whitehall' pages |
 | world_locations | STRING | NULLABLE | The content attribute of the `<meta name="govuk:analytics:world-locations">` tag |
 | dclid | STRING | NULLABLE | The Google Marketing Platform (GMP) identifier that was collected with the event |
-| debug_mode | INTEGER | NULLABLE | |
-| engaged_session_event | INTEGER | NULLABLE |  |
+| debug_mode | INTEGER | NULLABLE | A flag to indicate whether Google Tag Manager's debug mode was being used to send these events e.g. '1' when debug mode was in use |
+| engaged_session_event | INTEGER | NULLABLE | The number of sessions the user is engaged in. Should always be '1' on GOV.UK as we do not use a user ID so cannot tell if a user visits the website from many devices |
 | entrances | INTEGER | NULLABLE | A flag to indicate an entrance, where '1' indicates an entrance |
-| firebase_conversion | INTEGER | NULLABLE | |
+| firebase_conversion | INTEGER | NULLABLE | firebase_conversion |
 | gclid | STRING | NULLABLE | The Google click identifier that was collected with the event |
-| gclsrc | STRING | NULLABLE | |
-| content | STRING | NULLABLE |  |
-| campaign_id | STRING | NULLABLE |  |
+| gclsrc | STRING | NULLABLE | The Google click identifier that indicates the source of the click ID |
+| content | STRING | NULLABLE | The 'content' campaign parameter, typically used to differentiate between two ads or links that point to the same URL |
+| campaign_id | STRING | NULLABLE | The ID of a promotion or marketing campaign that led to a key event |
 | index_section | INTEGER | NULLABLE | The index of the section that was interacted with e.g. if the third tab was clicked the index would be '3' |
 | index_section_total | INTEGER | NULLABLE | The total number of sections within a feature e.g. if there are five tabs in total this would be '5' |
-| tool_name | STRING | NULLABLE | The name of the tool (the smart answer or form)|
+| tool_name | STRING | NULLABLE | The name of the tool (the smart answer or form) |
 | response | STRING | NULLABLE | The user's reponse to a form question or error message |
 | ab_test | STRING | NULLABLE | The [content attribute of the `<meta name="govuk:ab-test">` tag](https://docs.publishing.service.gov.uk/analytics/attribute_ab_test.html) |
 | navigation_list_type | STRING | NULLABLE | The content attribute of the `<meta name="govuk:navigation-list-type">` tag |
 | navigation_page_type | STRING | NULLABLE | The content attribute of the `<meta name="govuk:navigation-page-type">` tag |
 | percent_scrolled | INTEGER | NULLABLE | The percentage scroll depth the user has reached |
-| sfmc_activity_id | STRING | NULLABLE | |
-| sfmc_activity_name | STRING | NULLABLE | |
-| sfmc_asset_id | STRING | NULLABLE | |
-| sfmc_channel | STRING | NULLABLE | |
-| sfmc_journey_id | STRING | NULLABLE | |
-| sfmc_journey_name | STRING | NULLABLE | |
+| sfmc_activity_id | STRING | NULLABLE | Session salesforce marketing cloud activity ID - not used |
+| sfmc_activity_name | STRING | NULLABLE | Session salesforce marketing cloud activity name - not used |
+| sfmc_asset_id | STRING | NULLABLE | Session salesforce marketing cloud asset ID - not used |
+| sfmc_channel | STRING | NULLABLE | Salesforce marketing cloud channel - not used |
+| sfmc_journey_id | STRING | NULLABLE | Salesforce marketing cloud journey ID - not used |
+| sfmc_journey_name | STRING | NULLABLE | Salesforce marketing cloud journey name - not used |
 | step_navs | STRING | NULLABLE | The content attribute of the `<meta name="govuk:stepnavs">` tag |
 | manual_campaign_id | STRING | NULLABLE | The manual campaign id (utm_id) that was collected with the event |
 | manual_campaign_name | STRING | NULLABLE | The manual campaign name (utm_campaign) that was collected with the event |
@@ -202,13 +202,13 @@ More information on the processing can be found in the [Policies and processes s
 | spelling_suggestion | STRING | NULLABLE | The spelling suggestion, if one is shown, on a search results page |
 | outcome | STRING | NULLABLE | The outcome reached at the end of form (only sent with form_complete events) |
 | viewport_size | STRING | NULLABLE | The size of the browser window, minus the scroll bars and toolbars, e.g. '1920x1080'. Note: in the flattening process, we only keep string values (a small number of integer and double values that are collected are not flattened) |
-| batch_page_id | INTEGER | NULLABLE | |
-| batch_ordering_id | INTEGER | NULLABLE | |
+| batch_page_id | INTEGER | NULLABLE | A unique identifier for each page view, allowing for the reconstruction of user interactions within a specific page |
+| batch_ordering_id | INTEGER | NULLABLE | A monotonically increasing number assigned to each network request sent from a page |
 | timestamp | INTEGER | NULLABLE | The [Unix timestamp](https://docs.publishing.service.gov.uk/analytics/attribute_timestamp.html) in milliseconds. This is a custom dimension, pushed with every dataLayer event, unlike the default event_timestamp above |
 | copy_length | INTEGER | NULLABLE | The number of characters in text copied ([copy events](https://docs.publishing.service.gov.uk/analytics/event_copy.html) only) |
 | item_list_name | STRING | NULLABLE | The name of the item list - on GOV.UK, this will be the name of a finder (search/search results) page |
 | item_id | STRING | NULLABLE | The URL of the search result item. A maximum of 200 search result items (the first 200) will be sent on longer search results pages |
-| item_name | STRING | NULLABLE | |
+| item_name | STRING | NULLABLE | The name of an item - on GOV.UK, the link text of a search result |
 | item_list_index | STRING | NULLABLE | The index of the search result item. A maximum of 200 search result items (the first 200) will be sent on longer search results pages |
 | item_content_id | STRING | NULLABLE | The content ID of the search result item |
 | emergency_banner | STRING | NULLABLE | Value is true if the user is served the emergency banner |

--- a/source/data-sources/ga/ga4-flat/index.html.md.erb
+++ b/source/data-sources/ga/ga4-flat/index.html.md.erb
@@ -60,7 +60,8 @@ mermaid.initialize({
 </script>
 
 This processing occurs within DataForm in the [gds-bq-reporting project](/tools/google-cloud-platform/gcp-projects/#gds-bigquery-reporting), but the data is written back into the [ga4-analytics-352613 project](/tools/google-cloud-platform/gcp-projects/#ga4-analytics).
-The DataForm script is compiled at 7am UTC and run at 8am UTC. The full code used can be [viewed in Github](https://github.com/alphagov/ga4-dataform/blob/main/definitions).
+The DataForm script is compiled at 7am UTC and run several times thoughout the day to ensure the data is processed soon after it arrives.
+The full code used can be [viewed in Github](https://github.com/alphagov/ga4-dataform/blob/main/definitions).
 
 More information on the processing can be found in the [Policies and processes section](/processes/ga4-data-processing/).
 
@@ -162,7 +163,7 @@ More information on the processing can be found in the [Policies and processes s
 | debug_mode | INTEGER | NULLABLE | A flag to indicate whether Google Tag Manager's debug mode was being used to send these events e.g. '1' when debug mode was in use |
 | engaged_session_event | INTEGER | NULLABLE | The number of sessions the user is engaged in. Should always be '1' on GOV.UK as we do not use a user ID so cannot tell if a user visits the website from many devices |
 | entrances | INTEGER | NULLABLE | A flag to indicate an entrance, where '1' indicates an entrance |
-| firebase_conversion | INTEGER | NULLABLE | firebase_conversion |
+| firebase_conversion | INTEGER | NULLABLE | A flag to indicate if an event is a firebase conversion. Not in use |
 | gclid | STRING | NULLABLE | The Google click identifier that was collected with the event |
 | gclsrc | STRING | NULLABLE | The Google click identifier that indicates the source of the click ID |
 | content | STRING | NULLABLE | The 'content' campaign parameter, typically used to differentiate between two ads or links that point to the same URL |
@@ -175,18 +176,19 @@ More information on the processing can be found in the [Policies and processes s
 | navigation_list_type | STRING | NULLABLE | The content attribute of the `<meta name="govuk:navigation-list-type">` tag |
 | navigation_page_type | STRING | NULLABLE | The content attribute of the `<meta name="govuk:navigation-page-type">` tag |
 | percent_scrolled | INTEGER | NULLABLE | The percentage scroll depth the user has reached |
-| sfmc_activity_id | STRING | NULLABLE | Session salesforce marketing cloud activity ID - not used |
-| sfmc_activity_name | STRING | NULLABLE | Session salesforce marketing cloud activity name - not used |
-| sfmc_asset_id | STRING | NULLABLE | Session salesforce marketing cloud asset ID - not used |
-| sfmc_channel | STRING | NULLABLE | Salesforce marketing cloud channel - not used |
-| sfmc_journey_id | STRING | NULLABLE | Salesforce marketing cloud journey ID - not used |
-| sfmc_journey_name | STRING | NULLABLE | Salesforce marketing cloud journey name - not used |
+| sfmc_activity_id | STRING | NULLABLE | Session salesforce marketing cloud activity ID |
+| sfmc_activity_name | STRING | NULLABLE | Session salesforce marketing cloud activity name |
+| sfmc_asset_id | STRING | NULLABLE | Session salesforce marketing cloud asset ID |
+| sfmc_channel | STRING | NULLABLE | Salesforce marketing cloud channel |
+| sfmc_journey_id | STRING | NULLABLE | Salesforce marketing cloud journey ID |
+| sfmc_journey_name | STRING | NULLABLE | Salesforce marketing cloud journey name |
 | step_navs | STRING | NULLABLE | The content attribute of the `<meta name="govuk:stepnavs">` tag |
 | manual_campaign_id | STRING | NULLABLE | The manual campaign id (utm_id) that was collected with the event |
 | manual_campaign_name | STRING | NULLABLE | The manual campaign name (utm_campaign) that was collected with the event |
 | manual_source | STRING | NULLABLE | The manual campaign source (utm_source) that was collected with the event. Also includes parsed parameters from referral params, not just UTM values |
 | manual_medium | STRING | NULLABLE | The manual campaign medium (utm_medium) that was collected with the event. Also includes parsed parameters from referral params, not just UTM values |
 | manual_term | STRING | NULLABLE | The manual campaign keyword/term (utm_term) that was collected with the event |
+| manual_content | STRING | NULLABLE | The manual content keyword/term (utm_content) that was collected with the event |
 | is_active_user | BOOLEAN | NULLABLE | Whether the user was active (True) or inactive (False) at any point in the calendar day |
 | video_title | STRING | NULLABLE | The title of the video (only sent with video type events) |
 | video_url | STRING | NULLABLE | The URL of the video (only sent with video type events) |
@@ -202,8 +204,9 @@ More information on the processing can be found in the [Policies and processes s
 | spelling_suggestion | STRING | NULLABLE | The spelling suggestion, if one is shown, on a search results page |
 | outcome | STRING | NULLABLE | The outcome reached at the end of form (only sent with form_complete events) |
 | viewport_size | STRING | NULLABLE | The size of the browser window, minus the scroll bars and toolbars, e.g. '1920x1080'. Note: in the flattening process, we only keep string values (a small number of integer and double values that are collected are not flattened) |
-| batch_page_id | INTEGER | NULLABLE | A unique identifier for each page view, allowing for the reconstruction of user interactions within a specific page |
-| batch_ordering_id | INTEGER | NULLABLE | A monotonically increasing number assigned to each network request sent from a page |
+| batch_page_id | INTEGER | NULLABLE | A (Google-created) unique identifier for each page view, allowing for the reconstruction of user interactions within a specific page. Added by Google in July 2024 |
+| batch_event_index | INTEGER | NULLABLE | A number indicating the sequential order of each event within a batch based on their order of occurrence on the device. Added by Google in July 2024 |
+| batch_ordering_id | INTEGER | NULLABLE | A monotonically increasing number assigned to each network request sent from a page. Added by Google in July 2024 |
 | timestamp | INTEGER | NULLABLE | The [Unix timestamp](https://docs.publishing.service.gov.uk/analytics/attribute_timestamp.html) in milliseconds. This is a custom dimension, pushed with every dataLayer event, unlike the default event_timestamp above |
 | copy_length | INTEGER | NULLABLE | The number of characters in text copied ([copy events](https://docs.publishing.service.gov.uk/analytics/event_copy.html) only) |
 | item_list_name | STRING | NULLABLE | The name of the item list - on GOV.UK, this will be the name of a finder (search/search results) page |
@@ -219,6 +222,8 @@ More information on the processing can be found in the [Policies and processes s
 | autocomplete_count | INTEGER | NULLABLE | The number of autocomplete suggestions shown |
 | canonical_url | STRING | NULLABLE | The [canonical URL](https://developers.google.com/search/docs/crawling-indexing/canonicalization) of the page, taken from the page header. Note that this is not present on all formats/document types |
 | traffic_type | STRING | NULLABLE | The traffic_type parameter set in the GA4 interface or in Google Tag Manager, to help us filter out internal or developer traffic and spam |
+| ignore_referrer | STRING | NULLABLE | Value of the ignore_referrer parameter |
+
 
 ### Retention
 At present, there is no default table expiry set up for this table, and no agreed data retention period.

--- a/source/data-sources/ga/ga4/data-quality/index.html.md.erb
+++ b/source/data-sources/ga/ga4/data-quality/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 data quality
 weight: 1
-last_reviewed_on: 2025-04-22
+last_reviewed_on: 2025-08-04
 review_in: 6 months
 ---
 
@@ -108,6 +108,14 @@ This can be seen on the live site, for example if you interact with the Contents
 Strictly, this URL should not be valid, but it (and many other incorrect URLs) do work to load content on GOV.UK.
 
 Use of URLs like this is rare and so this should not cause too much of a data quality issue.
+
+#### Issues with the full link URL
+
+The way in which the full link clicked as part of a navigation event has been collected into GA4 has varied over time.
+Due to GA4's character count limits on parameter values (previously set to 100 characters per parameter value), the `link_url` field was frequently heavily truncated when first implemented.
+To work around this, in February 2023 we implemented a solution which split these fields across five sub-fields, which were then concatenated togeter in the `full_link_url` field.
+Later in 2023, Google increased the character count limit on parameter values to 500, so the default 'link_url' field started to function as expected.
+We deprecated the link_path_parts sub-fields so the 'full_link_url' now only contains the 'link_domain'.
 
 #### Issues with publication and update dates
 The `first_published_at`, `public_updated_at` and `updated_at` dates sent with page view events may be misleading.

--- a/source/data-sources/ga/ga4/data-quality/index.html.md.erb
+++ b/source/data-sources/ga/ga4/data-quality/index.html.md.erb
@@ -135,7 +135,7 @@ There is also a known bug with the `browse_topic` field which can leave it comin
 
 The way in which taxonomy information has been collected into GA4 has also varied over time.
 Due to GA4's character count limits on parameter values (previously set to 100 characters per parameter value), the `taxonomy_all` and `taxonomy_all_ids` fields were frequently heavily truncated when first implemented.
-To work around this, in February 2023 we implemented a solution which split these fields across five sub-fields, which were then concatenated togeter in the `full_taxonomy` and `full_taxonomy_ids` fields, and the `taxonomy_all` and `taxonomy_all_ids` fields were left empty.
+To work around this, in February 2023 we implemented a solution which split these fields across five sub-fields, which were then concatenated together in the `full_taxonomy` and `full_taxonomy_ids` fields, and the `taxonomy_all` and `taxonomy_all_ids` fields were left empty.
 Later in 2023, Google increased the character count limit on parameter values to 500, so in November we switched back to the `taxonomy_all` and `taxonomy_all_ids` fields.
 We have renamed the 'full' taxonomy fields to `full_taxonomy_DEPRECATED` and `full_taxonomy_ids_DEPRECATED` as they are now not being populated (since November 2023), although they still contain the data for February to November 2023 should that be required.
 


### PR DESCRIPTION
Adding updated GA4 definitions plus batch_event_index note, linked to https://gov-uk.atlassian.net/browse/IA-1345 and https://gov-uk.atlassian.net/browse/IA-1434