### PR TITLE
Flattened definitions update plus internal navigation guidance

### DIFF
--- a/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
+++ b/source/analysis/govuk-ga4/find-in-ga4/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Find things in the GOV.UK GA4 data
 weight: 6
-last_reviewed_on: 2025-08-12
+last_reviewed_on: 2025-09-18
 review_in: 6 months
 ---
 
@@ -66,7 +66,6 @@ ORDER BY
   pageviews DESC
 ```
 
-
 ### Page views filtered to a certain publishing organisation
 
 In GA4, there are two custom dimensions you can use to identify different organisations:
@@ -90,7 +89,8 @@ Remember to check the [data quality icons](https://support.google.com/analytics/
 Link clicks are now tracked as events with the event name ‘navigation’.
 External links will be navigation events with the ‘outbound’ parameter/custom dimension set to ‘true’.
 Internal links (links to other pages on GOV.UK) will not have the parameter/custom dimension ‘outbound’ equalling ‘true’.
-Not all internal links have specific tracking on them.
+Not all internal links have specific tracking on them. 
+If you would like to figure out how much internal links without tracking are used, you can do this using the [page referrer](/analysis/govuk-ga4/find-in-ga4/#using-the-page-referrer).
 
 These events should all have dimensions such as the ‘Link URL’, ‘Link text’ and so on which should help you identify which links have been clicked.
 
@@ -133,7 +133,6 @@ GROUP BY
 ORDER BY
   events DESC
 ```
-
 
 ## File downloads
 
@@ -188,7 +187,6 @@ GROUP BY
 ORDER BY
   file_downloads DESC
 ```
-
 
 ## Search terms
 
@@ -286,6 +284,26 @@ You can also use funnel explorations to examine users' flow through pre-defined 
 Google have published some information on how to use [funnel explorations here](https://support.google.com/analytics/answer/9327974).
 
 Using the BigQuery data, however, you can view users' journeys in much more detail.
+
+### Using the page referrer
+
+In the interface, in Looker Studio, and in the BigQuery data, you can look at users' page locations and page referrers to see which page on GOV.UK they were on previously that led them to the current page.
+
+This can be particularly useful when trying to figure out if internal links are used to navigate between certain pages, as some internal link clicks are not tracked.
+
+#### Using the page referrer to see which internal links are clicked on a page - method in an exploration
+
+Steps:
+
+1. Create a blank [exploration](https://analytics.google.com/analytics/web/#/analysis/p330577055), and add in the ‘Page location’ and 'Page referrer' dimensions, along with the 'Event count' metric, using the '+' buttons in the 'Variables' tab
+2. Add the ‘Page location’ dimension and the 'Event count' metric to the table. You can do this by either dragging and dropping/selecting the 'Page path' dimension in the 'Rows' area in the 'Settings' tab, and doing the same to the 'Views' metric for the 'Values' area, or by just double-clicking on the dimension and metrics you want to use (they should automatically be assigned to be a row and a value in the table settings when you do this)
+3. Filter the data by the ‘Page referrer’ dimension to equals/contains the URL of the page you are interested in finding journeys from
+4. Change the date range and sort the table
+
+This should give you a table showing the pages on GOV.UK that were navigated to from your given referrer page and the number of times each was navigated to (the count).
+
+If you are unfamiliar with filtering GA4 data, it may be helpful to include the ‘Event name’ and ‘Page referrer’ dimensions in your table to check that your filters have worked correctly.
+You should only be able to see ‘view_item_list’ in the ‘Event name’ column and the specific page you want search terms from in the ‘Page referrer’ column.
 
 ### Ordering users' events
 

--- a/source/data-sources/ga/ga4-flat/index.html.md.erb
+++ b/source/data-sources/ga/ga4-flat/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 flattened table
 weight: 3
-last_reviewed_on: 2025-08-14
+last_reviewed_on: 2025-09-18
 review_in: 6 months
 ---
 
@@ -219,8 +219,7 @@ More information on the processing can be found in the [Policies and processes s
 | autocomplete_count | INTEGER | NULLABLE | The number of autocomplete suggestions shown |
 | canonical_url | STRING | NULLABLE | The [canonical URL](https://developers.google.com/search/docs/crawling-indexing/canonicalization) of the page, taken from the page header. Note that this is not present on all formats/document types |
 | traffic_type | STRING | NULLABLE | The traffic_type parameter set in the GA4 interface or in Google Tag Manager, to help us filter out internal or developer traffic and spam |
-| ignore_referrer | STRING | NULLABLE | Value of the ignore_referrer parameter |
-
+| ignore_referrer | STRING | NULLABLE | Value of the ignore_referrer parameter, a flag used by Google to determine whether or not to use a given referrer to generate attribution information |
 
 ### Retention
 At present, there is no default table expiry set up for this table, and no agreed data retention period.

--- a/source/processes/ga-modifications/index.html.md.erb
+++ b/source/processes/ga-modifications/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 data modifications
 weight: 5
-last_reviewed_on: 2024-11-25
+last_reviewed_on: 2025-09-12
 review_in: 6 months
 ---
 

--- a/source/processes/ga4-data-display/index.html.md.erb
+++ b/source/processes/ga4-data-display/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: GOV.UK GA4 data display settings
 weight: 6
-last_reviewed_on: 2024-11-25
+last_reviewed_on: 2025-09-12
 review_in: 6 months
 ---
 
@@ -15,6 +15,18 @@ Audiences in GA4 assist you in segmenting different groups of users.
 
 Property editors or administrators can create audiences within the property's Admin area.
 See [Google's documentation](https://support.google.com/analytics/answer/9267572?hl=en#create-an-audience&zippy=%2Cin-this-article) for further information on how to do this.
+
+##Channel groups
+
+Channels enable monitoring of the performance of the various sources sending traffic to the website.
+Google's default channel groups cannot be edited. 
+
+Property editors or administrators can create custom channel groups within the property's Admin area.
+See [Google's documentation](https://support.google.com/analytics/answer/13051316) for further information on how to do this.
+
+We are reluctant to create many custom channel groups due to the time required to then maintain these groups and the fact that these can be viewed by all users of the property, so possibly require further explanation and documentation.
+
+If you are interested in creating custom channel groups in the GOV.UK GA4 property, please contact the [GA4 support inbox](mailto:govuk-ga4-support@digital.cabinet-office.gov.uk).
 
 ##Expanded data sets
 


### PR DESCRIPTION
Updates to flattened table definitions (on the ignore_referrer field) plus some additional guidance on figuring out internal navigation using the page_referrer and notes on custom channel groups