### PR TITLE
Revert "Bump concurrent-ruby from 1.3.4 to 1.3.7"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    concurrent-ruby (1.3.7)
+    concurrent-ruby (1.3.4)
     connection_pool (2.5.5)
     contracts (0.16.1)
     crass (1.0.6)
@@ -172,25 +172,26 @@ GEM
       rouge
       sprockets (>= 3)
       sprockets-rails
-    govuk_tech_docs (6.3.0)
-      autoprefixer-rails
-      chronic
-      concurrent-ruby
+    govuk_tech_docs (4.2.0)
+      autoprefixer-rails (~> 10.2)
+      base64
+      bigdecimal
+      chronic (~> 0.10.2)
+      concurrent-ruby (= 1.3.4)
       csv
-      haml (>= 6, < 8)
-      middleman
-      middleman-autoprefixer
-      middleman-compass
+      haml (~> 6.0)
+      middleman (~> 4.0)
+      middleman-autoprefixer (~> 2.10)
+      middleman-compass (~> 4.0)
       middleman-livereload
       middleman-search-gds
-      middleman-sprockets (= 4.0.0)
-      middleman-syntax
+      middleman-sprockets (~> 4.0.0)
+      middleman-syntax (~> 3.4)
       mutex_m
       nokogiri
-      openapi3_parser
-      redcarpet
-      sassc-embedded
-      schmooze (~> 0.2.0)
+      openapi3_parser (~> 0.9.0)
+      redcarpet (~> 3.6)
+      sassc-embedded (~> 1.78.0)
       terser (~> 1.2.3)
     haml (6.3.0)
       temple (>= 0.8.2)
@@ -587,7 +588,6 @@ GEM
       ffi (~> 1.9)
     sassc-embedded (1.78.0)
       sass-embedded (~> 1.78)
-    schmooze (0.2.0)
     securerandom (0.4.1)
     sentry-rails (6.3.0)
       railties (>= 5.2.0)


### PR DESCRIPTION
Reverts alphagov/data-community-tech-docs#474