### PR TITLE
Add permissions to Dependency Review scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,3 +26,4 @@ jobs:
   dependency-review:
     name: Dependency Review scan
     uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
+    permissions: read-all


### PR DESCRIPTION
To address this alert: https://github.com/alphagov/data-community-tech-docs/security/code-scanning/1

adding read only permissions as it shouldn't need to write anything